### PR TITLE
Add CHAOSS activity and OpenSSF badge collectors (4.2.4, 4.2.5)

### DIFF
--- a/collectors/sustainability/base.py
+++ b/collectors/sustainability/base.py
@@ -1,0 +1,49 @@
+"""Shared base class for GitHub-based sustainability collectors."""
+
+import re
+import httpx
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class GitHubCollectorBase:
+    """Provides shared GitHub API utilities for sustainability collectors."""
+
+    def __init__(self, github_token: Optional[str] = None):
+        if github_token:
+            self.github_headers = {
+                "Authorization": f"token {github_token}",
+                "Accept": "application/vnd.github.v3+json",
+            }
+        else:
+            self.github_headers = {"Accept": "application/vnd.github.v3+json"}
+
+    def _extract_owner_repo(self, repo_url: str) -> Optional[tuple]:
+        """Extract (owner, repo) from a GitHub URL."""
+        patterns = [
+            r"github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$",
+            r"github\.com:([^/]+)/([^/]+?)(?:\.git)?/?$",
+        ]
+        for pattern in patterns:
+            match = re.search(pattern, repo_url)
+            if match:
+                return (match.group(1), match.group(2).replace(".git", ""))
+        return None
+
+    async def _check_file_exists(
+        self, client: httpx.AsyncClient, owner: str, repo: str, path: str
+    ) -> bool:
+        """Return True if the given path exists in the repository."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
+        try:
+            response = await client.get(url, headers=self.github_headers)
+            return response.status_code == 200
+        except Exception:
+            return False
+
+    def _get_timestamp(self) -> str:
+        """Return current UTC timestamp in ISO format."""
+        return datetime.now(timezone.utc).isoformat()

--- a/collectors/sustainability/chaoss_governance.py
+++ b/collectors/sustainability/chaoss_governance.py
@@ -1,0 +1,549 @@
+"""
+CHAOSS Activity Metrics Collector (CASS Report Section 4.2.4)
+
+Collects CHAOSS-defined metrics covering:
+- Issues Inclusivity: Unique issue author count as a proxy for participation breadth
+  (NOTE: this is a rough proxy — it counts authors, not demographic diversity)
+- Documentation Usability: README quality and documentation presence
+- Time to Close: Average time to resolve issues
+- Change Request Closure Ratio: Percentage of PRs merged vs closed without merge
+- Project Popularity: Stars, forks, watchers
+- Issue Age: Distribution of open issue ages
+- Release Frequency: Cadence of new releases
+
+CHAOSS Metrics Reference: https://chaoss.community/metrics/
+"""
+
+import asyncio
+import base64
+import httpx
+import logging
+import re
+from datetime import datetime, timezone, timedelta
+from statistics import mean, median
+from typing import Any, Dict, List, Optional
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+# Scoring thresholds — chosen to reflect typical OSS project health ranges.
+# Stars: 1000 stars ≈ 100 points; Forks: 200 forks ≈ 100; Watchers: 100 ≈ 100.
+_POPULARITY_STAR_SCALE = 1000
+_POPULARITY_FORK_SCALE = 200
+_POPULARITY_WATCH_SCALE = 100
+
+# Time-to-close brackets (days → score): faster response earns higher score.
+_TIME_CLOSE_BRACKETS = [(7, 100), (30, 80), (90, 60), (180, 40)]
+_TIME_CLOSE_DEFAULT_SCORE = 20
+
+# Release frequency brackets (avg days between releases → score).
+_RELEASE_FREQ_BRACKETS = [(30, 100), (90, 80), (180, 60), (365, 40)]
+_RELEASE_FREQ_DEFAULT_SCORE = 20
+
+# Issue age brackets (avg open issue age in days → score).
+_ISSUE_AGE_BRACKETS = [(30, 100), (90, 80), (180, 60), (365, 40)]
+_ISSUE_AGE_DEFAULT_SCORE = 20
+
+# Issues are considered stale after this many days open.
+_STALE_ISSUE_DAYS = 180
+
+
+def _bracket_score(value: float, brackets: list, default: int) -> int:
+    """Return a score by finding the first bracket threshold >= value."""
+    for threshold, score in brackets:
+        if value <= threshold:
+            return score
+    return default
+
+
+class CHAOSSGovernanceCollector(GitHubCollectorBase):
+    """Collects CHAOSS-defined activity health indicators (Section 4.2.4)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        repo_url = package.get("repo_url", "")
+
+        logger.info(f"Collecting CHAOSS metrics for {repo_name}")
+
+        owner_repo = self._extract_owner_repo(repo_url)
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {repo_url}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            results = await asyncio.gather(
+                self._get_project_popularity(client, owner, repo),
+                self._get_documentation_usability(client, owner, repo),
+                self._get_issue_metrics(client, owner, repo),
+                self._get_change_request_metrics(client, owner, repo),
+                self._get_release_frequency(client, owner, repo),
+                self._get_issues_inclusivity(client, owner, repo),
+                return_exceptions=True,
+            )
+
+        popularity = results[0] if not isinstance(results[0], Exception) else {}
+        documentation = results[1] if not isinstance(results[1], Exception) else {}
+        issue_metrics = results[2] if not isinstance(results[2], Exception) else {}
+        pr_metrics = results[3] if not isinstance(results[3], Exception) else {}
+        release_freq = results[4] if not isinstance(results[4], Exception) else {}
+        inclusivity = results[5] if not isinstance(results[5], Exception) else {}
+
+        overall_score = self._calculate_overall_score(
+            popularity, documentation, issue_metrics, pr_metrics, release_freq, inclusivity
+        )
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "chaoss_metrics": {
+                "project_popularity": popularity,
+                "documentation_usability": documentation,
+                "time_to_close": issue_metrics.get("time_to_close", {}),
+                "issue_age": issue_metrics.get("issue_age", {}),
+                "change_request_closure_ratio": pr_metrics.get("closure_ratio", {}),
+                "release_frequency": release_freq,
+                "issues_inclusivity": inclusivity,
+            },
+            "overall_score": overall_score,
+            "assessment_method": "chaoss_activity_metrics",
+            "chaoss_reference": "https://chaoss.community/metrics/",
+        }
+
+    # ------------------------------------------------------------------ #
+    # Metric collectors                                                    #
+    # ------------------------------------------------------------------ #
+
+    async def _get_project_popularity(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """CHAOSS: Project Popularity — stars, forks, watchers."""
+        url = f"https://api.github.com/repos/{owner}/{repo}"
+        try:
+            response = await client.get(url, headers=self.github_headers)
+            if response.status_code != 200:
+                logger.warning(f"Popularity fetch failed: {response.status_code}")
+                return {}
+            data = response.json()
+            stars = data.get("stargazers_count", 0)
+            forks = data.get("forks_count", 0)
+            watchers = data.get("watchers_count", 0)
+            star_score = min(100, (stars / _POPULARITY_STAR_SCALE) * 100) if stars else 0
+            fork_score = min(100, (forks / _POPULARITY_FORK_SCALE) * 100) if forks else 0
+            watch_score = min(100, (watchers / _POPULARITY_WATCH_SCALE) * 100) if watchers else 0
+            avg_score = (star_score + fork_score + watch_score) / 3
+            logger.info(f"  Stars: {stars}, Forks: {forks}, Watchers: {watchers}")
+            return {
+                "stars": stars,
+                "forks": forks,
+                "watchers": watchers,
+                "subscribers": data.get("subscribers_count", 0),
+                "score": round(avg_score, 2),
+                "created_at": data.get("created_at"),
+                "updated_at": data.get("updated_at"),
+            }
+        except Exception as e:
+            logger.error(f"Error getting popularity: {e}")
+            return {}
+
+    async def _get_documentation_usability(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """CHAOSS: Documentation Usability — README quality and docs presence."""
+        found_docs = []
+        doc_details: Dict[str, Any] = {}
+
+        readme_data = await self._get_readme_content(client, owner, repo)
+        if readme_data:
+            found_docs.append("readme")
+            quality = self._assess_readme_quality(readme_data.get("content", ""))
+            doc_details["readme"] = {"exists": True, "size": readme_data.get("size", 0), "quality_score": quality}
+            logger.info(f"  README found (quality: {quality}/100)")
+        else:
+            doc_details["readme"] = {"exists": False, "quality_score": 0}
+
+        for pattern in ["CONTRIBUTING.md", ".github/CONTRIBUTING.md"]:
+            if await self._check_file_exists(client, owner, repo, pattern):
+                found_docs.append("contributing")
+                doc_details["contributing"] = {"exists": True, "file": pattern}
+                break
+        else:
+            doc_details["contributing"] = {"exists": False}
+
+        for pattern in ["docs/", "documentation/", "doc/"]:
+            if await self._check_file_exists(client, owner, repo, pattern):
+                found_docs.append("docs_folder")
+                doc_details["docs_folder"] = {"exists": True, "path": pattern}
+                break
+        else:
+            doc_details["docs_folder"] = {"exists": False}
+
+        has_wiki = await self._check_wiki_enabled(client, owner, repo)
+        if has_wiki:
+            found_docs.append("wiki")
+        doc_details["wiki"] = {"exists": has_wiki}
+
+        max_docs = 4
+        base_score = (len(found_docs) / max_docs) * 100
+        readme_quality = doc_details.get("readme", {}).get("quality_score", 0)
+        doc_score = (base_score * 0.6) + (readme_quality * 0.4)
+
+        return {
+            "score": round(doc_score, 2),
+            "found": found_docs,
+            "details": doc_details,
+            "count": len(found_docs),
+            "max_count": max_docs,
+        }
+
+    async def _get_issue_metrics(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """CHAOSS: Time to Close and Issue Age."""
+        closed_issues = await self._get_closed_issues(client, owner, repo, limit=30)
+        open_issues = await self._get_open_issues(client, owner, repo, limit=50)
+        return {
+            "time_to_close": self._calculate_time_to_close(closed_issues),
+            "issue_age": self._calculate_issue_age(open_issues),
+        }
+
+    async def _get_change_request_metrics(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """CHAOSS: Change Request Closure Ratio — merged vs closed-without-merge."""
+        closed_prs = await self._get_closed_pull_requests(client, owner, repo, limit=50)
+        if not closed_prs:
+            return {"closure_ratio": {"total": 0, "merged": 0, "closed_without_merge": 0, "ratio": 0, "score": 0}}
+
+        merged = sum(1 for pr in closed_prs if pr.get("merged_at"))
+        closed_without_merge = len(closed_prs) - merged
+        ratio = (merged / len(closed_prs)) * 100
+
+        logger.info(f"  PRs merged: {merged}/{len(closed_prs)} ({ratio:.1f}%)")
+        return {
+            "closure_ratio": {
+                "total": len(closed_prs),
+                "merged": merged,
+                "closed_without_merge": closed_without_merge,
+                "ratio": round(ratio, 2),
+                "score": round(ratio, 2),
+            }
+        }
+
+    async def _get_release_frequency(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """CHAOSS: Release Frequency — cadence of new releases."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/releases"
+        try:
+            response = await client.get(url, headers=self.github_headers, params={"per_page": 30})
+            if response.status_code != 200:
+                return {}
+            releases = response.json()
+            if not releases:
+                return {"total_releases": 0, "recent_releases": 0, "avg_days_between_releases": 0, "latest_release": None, "score": 0}
+
+            now = datetime.now(timezone.utc)
+            one_year_ago = now - timedelta(days=365)
+            recent_releases = [r for r in releases if self._parse_date(r.get("published_at")) and self._parse_date(r.get("published_at")) > one_year_ago]
+
+            avg_days = 0.0
+            if len(releases) >= 2:
+                release_dates = sorted(
+                    filter(None, (self._parse_date(r.get("published_at")) for r in releases[:10])),
+                    reverse=True,
+                )
+                if len(release_dates) >= 2:
+                    gaps = [(release_dates[i] - release_dates[i + 1]).days for i in range(len(release_dates) - 1)]
+                    avg_days = mean(gaps)
+
+            freq_score = _bracket_score(avg_days, _RELEASE_FREQ_BRACKETS, _RELEASE_FREQ_DEFAULT_SCORE) if avg_days else 0
+            latest = releases[0]
+            logger.info(f"  {len(recent_releases)} releases in last year, avg {avg_days:.0f} days between")
+            return {
+                "total_releases": len(releases),
+                "recent_releases": len(recent_releases),
+                "avg_days_between_releases": round(avg_days, 1),
+                "latest_release": {"tag": latest.get("tag_name"), "published_at": latest.get("published_at")},
+                "score": freq_score,
+            }
+        except Exception as e:
+            logger.error(f"Error getting releases: {e}")
+            return {}
+
+    async def _get_issues_inclusivity(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """CHAOSS: Issues Inclusivity — unique author count across recent issues.
+
+        Limitation: this is a rough proxy. It counts distinct issue authors as
+        an indicator of participation breadth, not demographic diversity or
+        depth of engagement.
+        """
+        issues = await self._get_recent_issues_with_comments(client, owner, repo, limit=30)
+        if not issues:
+            return {"total_issues": 0, "unique_participants": 0, "avg_participants_per_issue": 0, "score": 0}
+
+        all_participants: set = set()
+        participants_per_issue = []
+        for issue in issues:
+            login = issue.get("user", {}).get("login")
+            if login:
+                all_participants.add(login)
+            # comments_count + 1 (author) gives a rough participation estimate per issue
+            participants_per_issue.append(min(issue.get("comments", 0) + 1, 10))
+
+        unique_count = len(all_participants)
+        avg_participants = mean(participants_per_issue) if participants_per_issue else 0
+        inclusivity_score = min(100, (unique_count / len(issues)) * 100)
+
+        logger.info(f"  {unique_count} unique participants across {len(issues)} issues")
+        return {
+            "total_issues": len(issues),
+            "unique_participants": unique_count,
+            "avg_participants_per_issue": round(avg_participants, 1),
+            "score": round(inclusivity_score, 2),
+        }
+
+    # ------------------------------------------------------------------ #
+    # HTTP helpers                                                         #
+    # ------------------------------------------------------------------ #
+
+    async def _get_readme_content(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Optional[Dict[str, Any]]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/readme"
+        try:
+            response = await client.get(url, headers=self.github_headers)
+            if response.status_code == 200:
+                data = response.json()
+                content = base64.b64decode(data.get("content", "")).decode("utf-8", errors="ignore")
+                return {"size": data.get("size", 0), "content": content}
+            return None
+        except Exception:
+            return None
+
+    async def _check_wiki_enabled(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> bool:
+        url = f"https://api.github.com/repos/{owner}/{repo}"
+        try:
+            response = await client.get(url, headers=self.github_headers)
+            return response.status_code == 200 and response.json().get("has_wiki", False)
+        except Exception:
+            return False
+
+    async def _get_closed_issues(
+        self, client: httpx.AsyncClient, owner: str, repo: str, limit: int = 30
+    ) -> List[Dict[str, Any]]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+        try:
+            response = await client.get(
+                url, headers=self.github_headers,
+                params={"state": "closed", "per_page": limit, "sort": "updated", "direction": "desc"},
+            )
+            if response.status_code == 200:
+                return [i for i in response.json() if "pull_request" not in i]
+        except Exception:
+            pass
+        return []
+
+    async def _get_open_issues(
+        self, client: httpx.AsyncClient, owner: str, repo: str, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+        try:
+            response = await client.get(
+                url, headers=self.github_headers,
+                params={"state": "open", "per_page": limit},
+            )
+            if response.status_code == 200:
+                return [i for i in response.json() if "pull_request" not in i]
+        except Exception:
+            pass
+        return []
+
+    async def _get_closed_pull_requests(
+        self, client: httpx.AsyncClient, owner: str, repo: str, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/pulls"
+        try:
+            response = await client.get(
+                url, headers=self.github_headers,
+                params={"state": "closed", "per_page": limit, "sort": "updated", "direction": "desc"},
+            )
+            if response.status_code == 200:
+                return response.json()
+        except Exception:
+            pass
+        return []
+
+    async def _get_recent_issues_with_comments(
+        self, client: httpx.AsyncClient, owner: str, repo: str, limit: int = 30
+    ) -> List[Dict[str, Any]]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues"
+        try:
+            response = await client.get(
+                url, headers=self.github_headers,
+                params={"state": "all", "per_page": limit, "sort": "updated", "direction": "desc"},
+            )
+            if response.status_code == 200:
+                return [i for i in response.json() if "pull_request" not in i]
+        except Exception:
+            pass
+        return []
+
+    # ------------------------------------------------------------------ #
+    # Pure computation helpers                                             #
+    # ------------------------------------------------------------------ #
+
+    def _assess_readme_quality(self, content: str) -> float:
+        """Score README quality 0–100 based on presence of key sections."""
+        if not content:
+            return 0.0
+        score = 0
+        sections = {
+            "installation": r"(?i)(install|setup|getting started)",
+            "usage": r"(?i)(usage|how to|example|quick start)",
+            "contributing": r"(?i)(contribut|development)",
+            "license": r"(?i)(license|copyright)",
+            "description": r"(?i)(description|about|overview|introduction)",
+        }
+        for pattern in sections.values():
+            if re.search(pattern, content):
+                score += 20
+        if len(content) > 1000:
+            score = min(100, score + 10)
+        if re.search(r"!\[.*?\]\(.*?\)", content):
+            score = min(100, score + 10)
+        return float(min(100, score))
+
+    def _calculate_time_to_close(self, closed_issues: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Compute time-to-close statistics from a list of closed issues."""
+        if not closed_issues:
+            return {"count": 0, "avg_days": 0, "median_days": 0, "min_days": 0, "max_days": 0, "score": 0}
+
+        days_to_close = []
+        for issue in closed_issues:
+            created = self._parse_date(issue.get("created_at"))
+            closed = self._parse_date(issue.get("closed_at"))
+            if created and closed:
+                days_to_close.append((closed - created).days)
+
+        if not days_to_close:
+            return {"count": 0, "avg_days": 0, "median_days": 0, "score": 0}
+
+        avg = mean(days_to_close)
+        logger.info(f"  Avg time to close: {avg:.1f} days (median: {median(days_to_close):.1f})")
+        return {
+            "count": len(days_to_close),
+            "avg_days": round(avg, 1),
+            "median_days": round(median(days_to_close), 1),
+            "min_days": min(days_to_close),
+            "max_days": max(days_to_close),
+            "score": _bracket_score(avg, _TIME_CLOSE_BRACKETS, _TIME_CLOSE_DEFAULT_SCORE),
+        }
+
+    def _calculate_issue_age(self, open_issues: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Compute age distribution of open issues."""
+        if not open_issues:
+            return {"count": 0, "avg_days": 0, "median_days": 0, "max_days": 0, "stale_issues": 0, "score": 0}
+
+        now = datetime.now(timezone.utc)
+        ages = []
+        for issue in open_issues:
+            created = self._parse_date(issue.get("created_at"))
+            if created:
+                ages.append((now - created).days)
+
+        if not ages:
+            return {"count": 0, "avg_days": 0, "score": 0}
+
+        avg = mean(ages)
+        stale = sum(1 for age in ages if age > _STALE_ISSUE_DAYS)
+        logger.info(f"  Avg issue age: {avg:.1f} days, {stale} stale issues")
+        return {
+            "count": len(ages),
+            "avg_days": round(avg, 1),
+            "median_days": round(median(ages), 1),
+            "max_days": max(ages),
+            "stale_issues": stale,
+            "stale_percentage": round((stale / len(ages)) * 100, 1),
+            "score": _bracket_score(avg, _ISSUE_AGE_BRACKETS, _ISSUE_AGE_DEFAULT_SCORE),
+        }
+
+    def _calculate_overall_score(
+        self,
+        popularity: Dict[str, Any],
+        documentation: Dict[str, Any],
+        issue_metrics: Dict[str, Any],
+        pr_metrics: Dict[str, Any],
+        release_freq: Dict[str, Any],
+        inclusivity: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Compute weighted overall CHAOSS health score (0–100)."""
+        pop_score = popularity.get("score", 0)
+        doc_score = documentation.get("score", 0)
+        time_close_score = issue_metrics.get("time_to_close", {}).get("score", 0)
+        issue_age_score = issue_metrics.get("issue_age", {}).get("score", 0)
+        pr_score = pr_metrics.get("closure_ratio", {}).get("score", 0)
+        release_score = release_freq.get("score", 0)
+        incl_score = inclusivity.get("score", 0)
+
+        weighted_score = (
+            pop_score * 0.15
+            + doc_score * 0.20
+            + time_close_score * 0.15
+            + issue_age_score * 0.10
+            + pr_score * 0.15
+            + release_score * 0.15
+            + incl_score * 0.10
+        )
+
+        if weighted_score >= 80:
+            status = "excellent"
+        elif weighted_score >= 60:
+            status = "good"
+        elif weighted_score >= 40:
+            status = "fair"
+        elif weighted_score >= 20:
+            status = "poor"
+        else:
+            status = "critical"
+
+        return {
+            "score": round(weighted_score, 2),
+            "max_score": 100,
+            "status": status,
+            "category_scores": {
+                "project_popularity": pop_score,
+                "documentation_usability": doc_score,
+                "time_to_close": time_close_score,
+                "issue_age": issue_age_score,
+                "change_request_closure_ratio": pr_score,
+                "release_frequency": release_score,
+                "issues_inclusivity": incl_score,
+            },
+        }
+
+    def _parse_date(self, date_str: Optional[str]) -> Optional[datetime]:
+        """Parse an ISO 8601 date string into a timezone-aware datetime."""
+        if not date_str:
+            return None
+        try:
+            return datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "chaoss_metrics": {},
+            "overall_score": {"score": 0, "max_score": 100, "status": "error"},
+            "assessment_method": "error",
+        }

--- a/collectors/sustainability/openssf_badge.py
+++ b/collectors/sustainability/openssf_badge.py
@@ -1,0 +1,312 @@
+"""
+OpenSSF Best Practices Badge Collector (CASS Report Section 4.2.5)
+
+Checks whether a project has an OpenSSF Best Practices Badge and reports
+badge level and criteria completion. When no badge exists, scans the
+repository to identify which governance, security, and quality requirements
+are already met.
+
+OpenSSF Badge API: https://bestpractices.coreinfrastructure.org/projects.json
+"""
+
+import asyncio
+import httpx
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+
+class OpenSSFBadgeCollector(GitHubCollectorBase):
+    """Collects OpenSSF Best Practices Badge metrics (Section 4.2.5)."""
+
+    BADGE_SEARCH_URL = "https://bestpractices.coreinfrastructure.org/projects.json"
+
+    # File patterns checked when no badge exists.
+    # These overlap intentionally with CommunityHealthCollector — OpenSSF uses
+    # the same artifacts to award badge criteria.
+    GOVERNANCE_FILES: Dict[str, List[str]] = {
+        "code_of_conduct": [
+            "CODE_OF_CONDUCT.md",
+            "CODE_OF_CONDUCT.txt",
+            "CODE-OF-CONDUCT.md",
+            "code_of_conduct.md",
+            "docs/CODE_OF_CONDUCT.md",
+            ".github/CODE_OF_CONDUCT.md",
+        ],
+        "governance": [
+            "GOVERNANCE.md",
+            "GOVERNANCE.txt",
+            "governance.md",
+            "docs/GOVERNANCE.md",
+            ".github/GOVERNANCE.md",
+        ],
+        "contributing": [
+            "CONTRIBUTING.md",
+            "CONTRIBUTING.txt",
+            "contributing.md",
+            "docs/CONTRIBUTING.md",
+            ".github/CONTRIBUTING.md",
+        ],
+    }
+
+    SECURITY_FILES: Dict[str, List[str]] = {
+        "security_policy": [
+            "SECURITY.md",
+            "SECURITY.txt",
+            "security.md",
+            "docs/SECURITY.md",
+            ".github/SECURITY.md",
+        ],
+        "vulnerability_process": [
+            "SECURITY.md",
+            ".github/SECURITY.md",
+            "docs/security.md",
+        ],
+    }
+
+    QUALITY_FILES: Dict[str, List[str]] = {
+        "ci_cd": [
+            ".github/workflows",
+            ".travis.yml",
+            ".circleci/config.yml",
+            ".gitlab-ci.yml",
+            "Jenkinsfile",
+        ],
+        "documentation": [
+            "README.md",
+            "docs/README.md",
+            "README",
+        ],
+        "testing": [
+            "test/",
+            "tests/",
+            "spec/",
+            ".github/workflows",
+        ],
+    }
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        repo_url = package.get("repo_url", "")
+
+        logger.info(f"Collecting OpenSSF Badge metrics for {repo_name}")
+
+        owner_repo = self._extract_owner_repo(repo_url)
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {repo_url}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            badge_data = await self._search_badge(client, owner, repo, repo_url)
+            if badge_data:
+                logger.info(f"Badge found — level: {badge_data.get('badge_level')}, progress: {badge_data.get('badge_percentage_0', 0)}%")
+                return self._collect_with_badge(repo_name, owner, repo, badge_data)
+            else:
+                logger.info("No badge found — scanning repository for requirements")
+                return await self._collect_without_badge(client, repo_name, owner, repo)
+
+    # ------------------------------------------------------------------ #
+    # Badge vs. scan paths                                                 #
+    # ------------------------------------------------------------------ #
+
+    def _collect_with_badge(
+        self, repo_name: str, owner: str, repo: str, badge_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        badge_level = self._get_badge_level(badge_data)
+        badge_percentage = badge_data.get("badge_percentage_0", 0)
+        badge_id = badge_data.get("id")
+        is_in_progress = badge_percentage > 0 and badge_percentage < 100
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "badge_exists": True,
+            "badge_status": {
+                "level": badge_level,
+                "id": badge_id,
+                "url": f"https://www.bestpractices.dev/projects/{badge_id}",
+                "progress_percentage": badge_percentage,
+                "in_progress": is_in_progress,
+                "started": badge_percentage > 0,
+            },
+            "governance_criteria": self._assess_governance_from_badge(badge_data),
+            "security_criteria": self._assess_security_from_badge(badge_data),
+            "quality_criteria": self._assess_quality_from_badge(badge_data),
+            "overall_score": {
+                "score": round(badge_percentage, 2),
+                "max_score": 100,
+                "percentage": round(badge_percentage, 2),
+                "status": "passing" if badge_percentage >= 100 else "in_progress" if badge_percentage > 0 else "not_started",
+            },
+            "assessment_method": "openssf_badge_api",
+        }
+
+    async def _collect_without_badge(
+        self, client: httpx.AsyncClient, repo_name: str, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        governance = await self._scan_files(client, owner, repo, self.GOVERNANCE_FILES)
+        security = await self._scan_files(client, owner, repo, self.SECURITY_FILES)
+        quality = await self._scan_files(client, owner, repo, self.QUALITY_FILES)
+
+        overall_pct = (
+            governance.get("percentage", 0) * 0.4
+            + security.get("percentage", 0) * 0.3
+            + quality.get("percentage", 0) * 0.3
+        )
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "badge_exists": False,
+            "badge_status": {
+                "level": "none",
+                "id": None,
+                "url": None,
+                "progress_percentage": 0,
+                "in_progress": False,
+                "started": False,
+            },
+            "governance_criteria": governance,
+            "security_criteria": security,
+            "quality_criteria": quality,
+            "overall_score": {
+                "score": round(overall_pct, 2),
+                "max_score": 100,
+                "percentage": round(overall_pct, 2),
+                "status": "not_started",
+                "estimated": True,
+            },
+            "assessment_method": "repository_scan",
+            "recommendation": "Start OpenSSF Badge at: https://www.bestpractices.dev/projects/new",
+        }
+
+    # ------------------------------------------------------------------ #
+    # HTTP helpers                                                         #
+    # ------------------------------------------------------------------ #
+
+    async def _search_badge(
+        self, client: httpx.AsyncClient, owner: str, repo: str, repo_url: str
+    ) -> Optional[Dict[str, Any]]:
+        headers = {"Accept": "application/json", "User-Agent": "CASS-Metrics-Collector"}
+        try:
+            response = await client.get(self.BADGE_SEARCH_URL, params={"url": repo_url}, headers=headers, follow_redirects=True)
+            if response.status_code == 200:
+                results = response.json()
+                if results:
+                    return results[0]
+
+            for query in [f"github.com/{owner}/{repo}", f"{owner}/{repo}"]:
+                response = await client.get(self.BADGE_SEARCH_URL, params={"q": query}, headers=headers, follow_redirects=True)
+                if response.status_code == 200:
+                    for result in response.json():
+                        if f"{owner}/{repo}".lower() in result.get("repo_url", "").lower():
+                            return result
+        except Exception as e:
+            logger.debug(f"Error searching for badge: {e}")
+        return None
+
+    async def _scan_files(
+        self,
+        client: httpx.AsyncClient,
+        owner: str,
+        repo: str,
+        file_map: Dict[str, List[str]],
+    ) -> Dict[str, Any]:
+        """Check each criterion in file_map against the repository."""
+        found: List[str] = []
+        missing: List[str] = []
+        details: Dict[str, Any] = {}
+
+        for criterion, patterns in file_map.items():
+            for pattern in patterns:
+                if await self._check_file_exists(client, owner, repo, pattern):
+                    found.append(criterion)
+                    details[criterion] = {
+                        "exists": True,
+                        "file": pattern,
+                        "url": f"https://github.com/{owner}/{repo}/blob/main/{pattern}",
+                    }
+                    logger.info(f"  {criterion}: {pattern}")
+                    break
+            else:
+                missing.append(criterion)
+                details[criterion] = {"exists": False, "recommended": patterns[0]}
+
+        count_total = len(file_map)
+        return {
+            "found": found,
+            "missing": missing,
+            "details": details,
+            "count_found": len(found),
+            "count_total": count_total,
+            "percentage": round((len(found) / count_total) * 100, 2) if count_total else 0,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Pure computation helpers                                             #
+    # ------------------------------------------------------------------ #
+
+    def _assess_governance_from_badge(self, badge_data: Dict[str, Any]) -> Dict[str, Any]:
+        return self._assess_criteria_from_badge(
+            badge_data, ["governance", "contribution", "contribution_requirements", "code_of_conduct"]
+        )
+
+    def _assess_security_from_badge(self, badge_data: Dict[str, Any]) -> Dict[str, Any]:
+        return self._assess_criteria_from_badge(
+            badge_data, ["vulnerability_report_process", "vulnerability_report_private", "security_policy"]
+        )
+
+    def _assess_quality_from_badge(self, badge_data: Dict[str, Any]) -> Dict[str, Any]:
+        return self._assess_criteria_from_badge(
+            badge_data, ["test", "test_continuous_integration", "documentation_basics"]
+        )
+
+    def _assess_criteria_from_badge(
+        self, badge_data: Dict[str, Any], criteria: List[str]
+    ) -> Dict[str, Any]:
+        met = []
+        unmet = []
+        details: Dict[str, Any] = {}
+        for criterion in criteria:
+            status = badge_data.get(f"{criterion}_status", "Unknown")
+            is_met = status == "Met"
+            (met if is_met else unmet).append(criterion)
+            details[criterion] = {"status": status, "met": is_met}
+        return {
+            "found": met,
+            "missing": unmet,
+            "details": details,
+            "count_found": len(met),
+            "count_total": len(criteria),
+            "percentage": round((len(met) / len(criteria)) * 100, 2) if criteria else 0,
+        }
+
+    def _get_badge_level(self, badge_data: Dict[str, Any]) -> str:
+        """Map numeric badge_level field to a human-readable string."""
+        level_map = {"2": "gold", "1": "silver", "0": "passing"}
+        level = level_map.get(str(badge_data.get("badge_level", "")))
+        if level:
+            return level
+        return "in_progress" if badge_data.get("badge_percentage_0", 0) > 0 else "none"
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "badge_exists": False,
+            "badge_status": {"level": "none", "id": None, "url": None, "progress_percentage": 0, "in_progress": False, "started": False},
+            "governance_criteria": {"found": [], "missing": [], "percentage": 0},
+            "security_criteria": {"found": [], "missing": [], "percentage": 0},
+            "quality_criteria": {"found": [], "missing": [], "percentage": 0},
+            "overall_score": {"score": 0, "max_score": 100, "percentage": 0, "status": "error"},
+            "assessment_method": "error",
+        }

--- a/config/orchestrator.yaml
+++ b/config/orchestrator.yaml
@@ -14,6 +14,14 @@ collectors:
   sustainability: true      # 4.2 Sustainability (governance, licensing, maintenance, engagement, ...)
   quality: false            # 4.3 Quality (reliability, dev practices, reproducibility, usability, ...)
 
+# Fine-grained toggles for individual sustainability sub-collectors (4.2.x)
+sustainability_collectors:
+  community_health: true    # 4.2.1 CoC, Governance, Contributor Guidelines
+  licensing: true           # 4.2.2 Licensing and FAIR Compliance
+  active_maintenance: true  # 4.2.3 Active Maintenance
+  chaoss_activity: true     # 4.2.4 CHAOSS Activity Metrics (issues, PRs, releases, docs)
+  openssf_badge: true       # 4.2.5 OpenSSF Best Practices Badge
+
 # API credentials
 api_credentials:
   github:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -217,6 +217,22 @@ class MetricsOrchestrator:
         except Exception as e:
             logger.warning(f"Active maintenance collection failed for {package['name']}: {e}")
 
+        # 4.2.4 CHAOSS Activity Metrics
+        try:
+            from collectors.sustainability.chaoss_governance import CHAOSSGovernanceCollector
+            collector = CHAOSSGovernanceCollector(github_token=github_token)
+            sub_results["chaoss_activity"] = await collector.collect(package)
+        except Exception as e:
+            logger.warning(f"CHAOSS activity collection failed for {package['name']}: {e}")
+
+        # 4.2.5 OpenSSF Best Practices Badge
+        try:
+            from collectors.sustainability.openssf_badge import OpenSSFBadgeCollector
+            collector = OpenSSFBadgeCollector(github_token=github_token)
+            sub_results["openssf_badge"] = await collector.collect(package)
+        except Exception as e:
+            logger.warning(f"OpenSSF badge collection failed for {package['name']}: {e}")
+
         # Calculate combined sustainability score from available sub-collectors
         scores = []
         if "governance" in sub_results:
@@ -225,6 +241,10 @@ class MetricsOrchestrator:
             scores.append(sub_results["licensing"].get("compliance_score", {}).get("percentage", 0))
         if "maintenance" in sub_results:
             scores.append(sub_results["maintenance"].get("score", {}).get("percentage", 0))
+        if "chaoss_activity" in sub_results:
+            scores.append(sub_results["chaoss_activity"].get("overall_score", {}).get("score", 0))
+        if "openssf_badge" in sub_results:
+            scores.append(sub_results["openssf_badge"].get("overall_score", {}).get("score", 0))
 
         avg_score = sum(scores) / len(scores) if scores else 0.0
 

--- a/tests/test_chaoss_governance.py
+++ b/tests/test_chaoss_governance.py
@@ -1,0 +1,168 @@
+"""Unit tests for CHAOSSGovernanceCollector pure computation methods."""
+
+import pytest
+from collectors.sustainability.chaoss_governance import CHAOSSGovernanceCollector
+
+
+@pytest.fixture
+def collector():
+    return CHAOSSGovernanceCollector()
+
+
+# ------------------------------------------------------------------ #
+# _assess_readme_quality                                               #
+# ------------------------------------------------------------------ #
+
+class TestAssessReadmeQuality:
+    def test_empty_returns_zero(self, collector):
+        assert collector._assess_readme_quality("") == 0.0
+
+    def test_all_sections_present(self, collector):
+        content = (
+            "## Installation\nsteps\n"
+            "## Usage\nexamples\n"
+            "## Contributing\ninfo\n"
+            "## License\nMIT\n"
+            "## About\ndescription\n"
+        )
+        assert collector._assess_readme_quality(content) == 100.0
+
+    def test_no_sections(self, collector):
+        assert collector._assess_readme_quality("just a short file") == 0.0
+
+    def test_length_bonus(self, collector):
+        # Only a license section (20 pts) + length bonus (+10)
+        content = "## License MIT\n" + "x" * 1001
+        score = collector._assess_readme_quality(content)
+        assert score == 30.0
+
+    def test_badge_bonus(self, collector):
+        # Use a URL that doesn't trigger any section regex
+        content = "## License MIT\n![ci](https://ci.server/badge.svg)"
+        score = collector._assess_readme_quality(content)
+        assert score == 30.0  # 20 (license) + 10 (badge)
+
+    def test_capped_at_100(self, collector):
+        content = (
+            "## Installation\n## Usage\n## Contributing\n## License\n## About\n"
+            "![badge](url)\n" + "x" * 1001
+        )
+        assert collector._assess_readme_quality(content) == 100.0
+
+
+# ------------------------------------------------------------------ #
+# _calculate_time_to_close                                             #
+# ------------------------------------------------------------------ #
+
+class TestCalculateTimeToClose:
+    def test_empty_list(self, collector):
+        result = collector._calculate_time_to_close([])
+        assert result["count"] == 0
+        assert result["score"] == 0
+
+    def test_fast_resolution(self, collector):
+        issues = [
+            {"created_at": "2024-01-01T00:00:00Z", "closed_at": "2024-01-03T00:00:00Z"},
+        ]
+        result = collector._calculate_time_to_close(issues)
+        assert result["avg_days"] == 2.0
+        assert result["score"] == 100  # <= 7 days
+
+    def test_medium_resolution(self, collector):
+        issues = [
+            {"created_at": "2024-01-01T00:00:00Z", "closed_at": "2024-01-20T00:00:00Z"},
+        ]
+        result = collector._calculate_time_to_close(issues)
+        assert result["score"] == 80  # <= 30 days
+
+    def test_slow_resolution(self, collector):
+        issues = [
+            {"created_at": "2024-01-01T00:00:00Z", "closed_at": "2024-06-01T00:00:00Z"},
+        ]
+        result = collector._calculate_time_to_close(issues)
+        assert result["score"] == 40  # <= 180 days
+
+    def test_very_slow_resolution(self, collector):
+        issues = [
+            {"created_at": "2023-01-01T00:00:00Z", "closed_at": "2024-01-01T00:00:00Z"},
+        ]
+        result = collector._calculate_time_to_close(issues)
+        assert result["score"] == 20  # > 180 days
+
+    def test_missing_dates_skipped(self, collector):
+        issues = [
+            {"created_at": None, "closed_at": "2024-01-03T00:00:00Z"},
+            {"created_at": "2024-01-01T00:00:00Z", "closed_at": "2024-01-04T00:00:00Z"},
+        ]
+        result = collector._calculate_time_to_close(issues)
+        assert result["count"] == 1
+        assert result["avg_days"] == 3.0
+
+
+# ------------------------------------------------------------------ #
+# _calculate_overall_score                                             #
+# ------------------------------------------------------------------ #
+
+class TestCalculateOverallScore:
+    def _make_score(self, collector, pop=0, doc=0, ttc=0, age=0, pr=0, rel=0, incl=0):
+        popularity = {"score": pop}
+        documentation = {"score": doc}
+        issue_metrics = {"time_to_close": {"score": ttc}, "issue_age": {"score": age}}
+        pr_metrics = {"closure_ratio": {"score": pr}}
+        release_freq = {"score": rel}
+        inclusivity = {"score": incl}
+        return collector._calculate_overall_score(
+            popularity, documentation, issue_metrics, pr_metrics, release_freq, inclusivity
+        )
+
+    def test_all_zeros_is_critical(self, collector):
+        result = self._make_score(collector)
+        assert result["score"] == 0.0
+        assert result["status"] == "critical"
+
+    def test_all_perfect_is_excellent(self, collector):
+        result = self._make_score(collector, 100, 100, 100, 100, 100, 100, 100)
+        assert result["score"] == 100.0
+        assert result["status"] == "excellent"
+
+    def test_status_good(self, collector):
+        result = self._make_score(collector, 70, 70, 70, 70, 70, 70, 70)
+        assert result["status"] == "good"
+
+    def test_status_fair(self, collector):
+        result = self._make_score(collector, 40, 40, 40, 50, 50, 50, 50)
+        assert result["status"] == "fair"
+
+    def test_weights_sum_to_one(self, collector):
+        # All inputs = 1 → weighted score should equal 1 × sum-of-weights = 1.0
+        result = self._make_score(collector, 1, 1, 1, 1, 1, 1, 1)
+        assert abs(result["score"] - 1.0) < 1e-9
+
+    def test_category_scores_present(self, collector):
+        result = self._make_score(collector, pop=50)
+        cats = result["category_scores"]
+        assert cats["project_popularity"] == 50
+        assert cats["documentation_usability"] == 0
+
+
+# ------------------------------------------------------------------ #
+# _parse_date                                                          #
+# ------------------------------------------------------------------ #
+
+class TestParseDate:
+    def test_none_returns_none(self, collector):
+        assert collector._parse_date(None) is None
+
+    def test_z_suffix(self, collector):
+        dt = collector._parse_date("2024-01-15T12:00:00Z")
+        assert dt is not None
+        assert dt.year == 2024
+        assert dt.tzinfo is not None
+
+    def test_offset_format(self, collector):
+        dt = collector._parse_date("2024-06-01T00:00:00+00:00")
+        assert dt is not None
+        assert dt.month == 6
+
+    def test_invalid_returns_none(self, collector):
+        assert collector._parse_date("not-a-date") is None

--- a/tests/test_openssf_badge.py
+++ b/tests/test_openssf_badge.py
@@ -1,0 +1,114 @@
+"""Unit tests for OpenSSFBadgeCollector pure computation methods."""
+
+import pytest
+from collectors.sustainability.openssf_badge import OpenSSFBadgeCollector
+
+
+@pytest.fixture
+def collector():
+    return OpenSSFBadgeCollector()
+
+
+# ------------------------------------------------------------------ #
+# _get_badge_level                                                     #
+# ------------------------------------------------------------------ #
+
+class TestGetBadgeLevel:
+    def test_gold(self, collector):
+        assert collector._get_badge_level({"badge_level": "2"}) == "gold"
+
+    def test_silver(self, collector):
+        assert collector._get_badge_level({"badge_level": "1"}) == "silver"
+
+    def test_passing(self, collector):
+        assert collector._get_badge_level({"badge_level": "0"}) == "passing"
+
+    def test_in_progress_when_percentage_nonzero(self, collector):
+        assert collector._get_badge_level({"badge_percentage_0": 45}) == "in_progress"
+
+    def test_none_when_no_data(self, collector):
+        assert collector._get_badge_level({}) == "none"
+
+    def test_none_when_zero_percentage(self, collector):
+        assert collector._get_badge_level({"badge_percentage_0": 0}) == "none"
+
+
+# ------------------------------------------------------------------ #
+# _assess_criteria_from_badge                                          #
+# ------------------------------------------------------------------ #
+
+class TestAssessCriteriaFromBadge:
+    def test_all_met(self, collector):
+        badge = {"governance_status": "Met", "contribution_status": "Met"}
+        result = collector._assess_criteria_from_badge(badge, ["governance", "contribution"])
+        assert result["count_found"] == 2
+        assert result["percentage"] == 100.0
+        assert result["missing"] == []
+
+    def test_none_met(self, collector):
+        badge = {"governance_status": "Unmet", "contribution_status": "Unmet"}
+        result = collector._assess_criteria_from_badge(badge, ["governance", "contribution"])
+        assert result["count_found"] == 0
+        assert result["percentage"] == 0.0
+        assert set(result["missing"]) == {"governance", "contribution"}
+
+    def test_partial(self, collector):
+        badge = {"governance_status": "Met", "contribution_status": "Unknown"}
+        result = collector._assess_criteria_from_badge(badge, ["governance", "contribution"])
+        assert result["count_found"] == 1
+        assert result["percentage"] == 50.0
+
+    def test_empty_criteria(self, collector):
+        result = collector._assess_criteria_from_badge({}, [])
+        assert result["percentage"] == 0
+        assert result["count_total"] == 0
+
+    def test_detail_structure(self, collector):
+        badge = {"governance_status": "Met"}
+        result = collector._assess_criteria_from_badge(badge, ["governance"])
+        assert result["details"]["governance"] == {"status": "Met", "met": True}
+
+
+# ------------------------------------------------------------------ #
+# _assess_governance/security/quality_from_badge (delegation checks) #
+# ------------------------------------------------------------------ #
+
+class TestAssessDelegation:
+    def test_governance_criteria_keys(self, collector):
+        result = collector._assess_governance_from_badge({})
+        assert "governance" in result["missing"]
+        assert "code_of_conduct" in result["missing"]
+
+    def test_security_criteria_keys(self, collector):
+        result = collector._assess_security_from_badge({})
+        assert "security_policy" in result["missing"]
+
+    def test_quality_criteria_keys(self, collector):
+        result = collector._assess_quality_from_badge({})
+        assert "test" in result["missing"]
+        assert "documentation_basics" in result["missing"]
+
+
+# ------------------------------------------------------------------ #
+# _collect_with_badge (pure logic, no I/O)                            #
+# ------------------------------------------------------------------ #
+
+class TestCollectWithBadge:
+    def test_passing_badge(self, collector):
+        badge_data = {
+            "badge_level": "0",
+            "badge_percentage_0": 100,
+            "id": 42,
+        }
+        result = collector._collect_with_badge("MyPkg", "owner", "repo", badge_data)
+        assert result["badge_exists"] is True
+        assert result["badge_status"]["level"] == "passing"
+        assert result["badge_status"]["progress_percentage"] == 100
+        assert result["overall_score"]["status"] == "passing"
+        assert result["assessment_method"] == "openssf_badge_api"
+
+    def test_in_progress_badge(self, collector):
+        badge_data = {"badge_level": None, "badge_percentage_0": 65, "id": 7}
+        result = collector._collect_with_badge("Pkg", "o", "r", badge_data)
+        assert result["badge_status"]["in_progress"] is True
+        assert result["overall_score"]["status"] == "in_progress"


### PR DESCRIPTION
## Summary

Implements the changes requested in the [PR #27 review](https://github.com/corsa-center/metrics/pull/27).

- **`collectors/sustainability/base.py`** — new `GitHubCollectorBase` eliminating the `_extract_owner_repo` / `_check_file_exists` / `_get_timestamp` duplication across sustainability collectors
- **`collectors/sustainability/chaoss_governance.py`** (§4.2.4) — CHAOSS activity metrics: project popularity, documentation usability, time-to-close, issue age, PR closure ratio, release frequency, and issues inclusivity
- **`collectors/sustainability/openssf_badge.py`** (§4.2.5) — OpenSSF Best Practices Badge lookup; falls back to repository file scanning when no badge exists
- **`orchestrator.py`** — both collectors wired into `collect_sustainability_dimension()` as 4.2.4 and 4.2.5; scores feed into the sustainability average
- **`config/orchestrator.yaml`** — added `sustainability_collectors` fine-grained toggles
- **`tests/`** — 38 unit tests covering all pure computation methods (38/38 passing)

## Review issues addressed

| Issue | Resolution |
|---|---|
| Shared base class | `GitHubCollectorBase` in `base.py` |
| Excessive `httpx.AsyncClient` instantiation | Single client per `collect()`, passed to helpers |
| `datetime.utcnow()` deprecated + tz-naive comparison bug | `datetime.now(timezone.utc)` throughout |
| `import base64` inside method body | Moved to top-level |
| Unused `import sys` in `main()` | Standalone `main()` stubs removed; orchestrator drives collection |
| Undocumented scoring thresholds | Named constants with explanatory comments |
| Inclusivity metric oversells what it measures | Limitation documented in docstring |
| Output filename (`4.2.-chaoss_activity.json`) | Not needed; output handled by orchestrator |
| No orchestrator integration | Wired as 4.2.4 and 4.2.5 |
| No tests | 38 unit tests added |
| No config update | `sustainability_collectors` section added |

## Test plan

- [ ] `python -m pytest tests/ -v` — all 38 tests pass
- [ ] Run orchestrator with `--dry-run` against a known repo and confirm `chaoss_activity` and `openssf_badge` appear in the sustainability sub-results