### PR TITLE
Add OpenSSF Scorecard and Accessibility collectors (4.3.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ data/cache/*
 # OS
 .DS_Store
 Thumbs.db
+
+
+#Ignore vscode AI rules
+.github/instructions/codacy.instructions.md

--- a/METRICS_ROADMAP.md
+++ b/METRICS_ROADMAP.md
@@ -1,0 +1,93 @@
+# Metrics Implementation Roadmap
+
+Grouped by ease of data collection, based on
+[corsa-center/metrics issues](https://github.com/corsa-center/metrics/issues)
+and the CASS Sustainability Metrics Report v3.
+
+---
+
+## Infrastructure (prerequisite, not metric-specific)
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| [#1](https://github.com/corsa-center/metrics/issues/1) | Phase 1: Infrastructure & Setup | ✅ Done |
+| [#2](https://github.com/corsa-center/metrics/issues/2) | Software Package Data Ingestion | ✅ Done |
+| [#3](https://github.com/corsa-center/metrics/issues/3) | GitHub/GitLab API Integration Framework | ✅ Done |
+| [#24](https://github.com/corsa-center/metrics/issues/24) | Metrics of interest file | 🔲 Todo |
+
+---
+
+## Easy — Direct GitHub/Repository API Queries
+
+File presence checks or structured data returned directly by GitHub/GitLab APIs.
+No significant post-processing required.
+
+| Issue | Metric | Collector | Status |
+|-------|--------|-----------|--------|
+| [#8](https://github.com/corsa-center/metrics/issues/8) | 4.2.1 CoC, Governance & Contributor Guidelines | `collectors/sustainability/chaoss_governance.py` | ✅ Done |
+| [#9](https://github.com/corsa-center/metrics/issues/9) | 4.2.2 Open-Source Licensing & FAIR Compliance | `collectors/sustainability/licensing.py` | ✅ Done |
+| [#10](https://github.com/corsa-center/metrics/issues/10) | 4.2.3 Active Maintenance | `collectors/sustainability/active_maintenance.py` | ✅ Done |
+| [#16](https://github.com/corsa-center/metrics/issues/16) | 4.2.10 Project Longevity & Community Health | `collectors/sustainability/community_health.py` | ✅ Done |
+| [#18](https://github.com/corsa-center/metrics/issues/18) | 4.3.2 Development Practices (CI/CD) | `collectors/quality/development_practices/ci_cd.py` | ✅ Done |
+| [#21](https://github.com/corsa-center/metrics/issues/21) | 4.3.5 Accessibility (portable build systems) | `collectors/quality/accessibility.py` | ✅ Done |
+| — | **OpenSSF Best Practices Badge** (Quality) | `collectors/sustainability/openssf_badge.py` | ✅ Done |
+| — | **OpenSSF Scorecard** (Sustainability) | `collectors/sustainability/openssf_scorecard.py` | ✅ Done |
+| — | **CI / GitHub Actions Status** (Quality) | covered by `ci_cd.py` | ✅ Done |
+
+### Why prioritised
+
+- All data is a single API call or file-existence check — no ML, no scraping, no
+  domain expertise required.
+- The three recommended new metrics are the lightest of all: each returns a
+  pre-computed score from a free public API.
+  - **OpenSSF Scorecard**: 3 projects (ADIOS, Viskores, PnetCDF) already report
+    real scores; free API at `api.securityscorecards.dev`.
+  - **OpenSSF Best Practices Badge**: 4 projects track it; ADIOS and HDF5 both
+    achieved "Passing" this quarter and cite it as their #1 quality metric.
+  - **CI / GitHub Actions Status**: 4 projects explicitly cite their CI pass
+    rate; GitHub API auth already wired in.
+
+---
+
+## Moderate — GitHub API + Analysis/Processing
+
+Data is available via APIs but requires aggregation, timestamp arithmetic,
+static analysis tool runs, or non-trivial content parsing.
+
+| Issue | Metric | Collector | Status |
+|-------|--------|-----------|--------|
+| [#6](https://github.com/corsa-center/metrics/issues/6) | 4.1.1 Software Citation & Adoption | `collectors/impact/citation.py` | ✅ Done (partial — CITATION.cff/DOI; advanced deps TBD) |
+| [#11](https://github.com/corsa-center/metrics/issues/11) | 4.2.4 Engagement | — | 🔲 Todo |
+| [#12](https://github.com/corsa-center/metrics/issues/12) | 4.2.5 Outreach | — | 🔲 Todo |
+| [#17](https://github.com/corsa-center/metrics/issues/17) | 4.3.1 Reliability & Robustness | — | 🔲 Todo |
+| [#19](https://github.com/corsa-center/metrics/issues/19) | 4.3.3 Reproducibility | — | 🔲 Todo |
+| [#20](https://github.com/corsa-center/metrics/issues/20) | 4.3.4 Usability | — | 🔲 Todo |
+| [#22](https://github.com/corsa-center/metrics/issues/22) | 4.3.6 Maintainability & Understandability | — | 🔲 Todo |
+
+---
+
+## Hard — External Data, AI/NLP, or Manual Assessment Required
+
+Data is not available from repository APIs alone; requires external services,
+ML models, specialized runtime instrumentation, or qualitative judgment.
+
+| Issue | Metric | Collector | Status |
+|-------|--------|-----------|--------|
+| [#7](https://github.com/corsa-center/metrics/issues/7) | 4.1.2 Field Research Impact | — | 🔲 Todo |
+| [#13](https://github.com/corsa-center/metrics/issues/13) | 4.2.7 Collaboration | — | 🔲 Todo |
+| [#14](https://github.com/corsa-center/metrics/issues/14) | 4.2.8 Financial Sustainability | — | 🔲 Todo |
+| [#15](https://github.com/corsa-center/metrics/issues/15) | 4.2.9 Institutional & Organizational Support | — | 🔲 Todo |
+| [#23](https://github.com/corsa-center/metrics/issues/23) | 4.3.7 Performance & Efficiency | — | 🔲 Todo |
+
+### Why hard
+
+- **4.1.2 Field Research Impact**: LLM-powered analysis of scientific literature
+  + HPC facility web scraping + DOI cross-referencing.
+- **4.2.7 Collaboration**: Multi-platform dependency mapping and cross-project
+  PR/issue network analysis.
+- **4.2.8 Financial Sustainability**: Funding amounts are often confidential;
+  requires `FUNDING.yml` parsing, NIH award DB lookups, and manual research.
+- **4.2.9 Institutional Support**: RSE position detection requires LinkedIn API
+  and institutional directory scraping; cannot be reliably automated.
+- **4.3.7 Performance & Efficiency**: Requires running benchmarks on target
+  hardware, GPU/CPU profiling (RAPL, NVML), and domain expertise to interpret.

--- a/collectors/quality/accessibility.py
+++ b/collectors/quality/accessibility.py
@@ -1,0 +1,160 @@
+"""
+Accessibility / Portability Collector (CASS Report Section 4.3.5)
+
+Detects the presence of portable build systems and container configurations
+that allow software to run across diverse computing environments.
+
+Checks (per the report):
+  - Container images     : Dockerfile, Singularity / Apptainer definition files
+  - Portable build tools : CMakeLists.txt, Spack recipe (package.py), Conda
+                           recipe (meta.yaml / environment.yml), Makefile,
+                           Autoconf (configure.ac / configure.in)
+  - Python packaging     : pyproject.toml, setup.py, setup.cfg
+  - Documentation        : INSTALL, INSTALL.md
+"""
+
+import asyncio
+import httpx
+import logging
+from typing import Any, Dict, List
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+# Each category maps a human-readable label to candidate file paths.
+_CHECKS: Dict[str, Dict[str, List[str]]] = {
+    "containers": {
+        "Docker": ["Dockerfile", "docker/Dockerfile", ".docker/Dockerfile"],
+        "Singularity / Apptainer": [
+            "Singularity",
+            "singularity/Singularity",
+            "Apptainer",
+            "apptainer/Apptainer",
+            "*.def",
+        ],
+    },
+    "build_systems": {
+        "CMake": ["CMakeLists.txt"],
+        "Spack": ["package.py", "spack/package.py"],
+        "Conda": [
+            "meta.yaml",
+            "conda/meta.yaml",
+            "recipe/meta.yaml",
+            "environment.yml",
+            "environment.yaml",
+        ],
+        "Autoconf": ["configure.ac", "configure.in"],
+        "Makefile": ["Makefile", "makefile", "GNUmakefile"],
+    },
+    "python_packaging": {
+        "pyproject.toml": ["pyproject.toml"],
+        "setup.py": ["setup.py"],
+        "setup.cfg": ["setup.cfg"],
+    },
+    "install_docs": {
+        "INSTALL": ["INSTALL", "INSTALL.md", "INSTALL.rst", "INSTALL.txt"],
+    },
+}
+
+
+class AccessibilityCollector(GitHubCollectorBase):
+    """Detects portable build systems and container configs (Section 4.3.5)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        repo_url = package.get("repo_url", "")
+
+        owner_repo = self._extract_owner_repo(repo_url)
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {repo_url}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Checking accessibility / portability for {owner}/{repo}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            return await self._scan(client, repo_name, owner, repo)
+
+    async def _scan(
+        self,
+        client: httpx.AsyncClient,
+        repo_name: str,
+        owner: str,
+        repo: str,
+    ) -> Dict[str, Any]:
+        category_results: Dict[str, Any] = {}
+        all_found: List[str] = []
+        all_missing: List[str] = []
+
+        for category, items in _CHECKS.items():
+            found: List[str] = []
+            missing: List[str] = []
+            details: Dict[str, Any] = {}
+
+            # Check each item in the category concurrently.
+            async def check_item(label: str, paths: List[str]) -> tuple:
+                for path in paths:
+                    if await self._check_file_exists(client, owner, repo, path):
+                        return label, path, True
+                return label, paths[0], False
+
+            results = await asyncio.gather(
+                *[check_item(label, paths) for label, paths in items.items()]
+            )
+
+            for label, matched_path, exists in results:
+                if exists:
+                    found.append(label)
+                    details[label] = {
+                        "exists": True,
+                        "file": matched_path,
+                        "url": f"https://github.com/{owner}/{repo}/blob/main/{matched_path}",
+                    }
+                    logger.debug(f"  {category}/{label}: {matched_path}")
+                else:
+                    missing.append(label)
+                    details[label] = {"exists": False}
+
+            all_found.extend(found)
+            all_missing.extend(missing)
+            total = len(items)
+            category_results[category] = {
+                "found": found,
+                "missing": missing,
+                "details": details,
+                "count_found": len(found),
+                "count_total": total,
+                "percentage": round(len(found) / total * 100, 1) if total else 0.0,
+            }
+
+        total_checks = len(all_found) + len(all_missing)
+        overall_pct = round(len(all_found) / total_checks * 100, 1) if total_checks else 0.0
+
+        has_container = bool(category_results["containers"]["found"])
+        has_portable_build = bool(category_results["build_systems"]["found"])
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "has_container": has_container,
+            "has_portable_build_system": has_portable_build,
+            "categories": category_results,
+            "overall_score": {
+                "score": len(all_found),
+                "max_score": total_checks,
+                "percentage": overall_pct,
+            },
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "has_container": False,
+            "has_portable_build_system": False,
+            "categories": {},
+            "overall_score": {"score": 0, "max_score": 0, "percentage": 0.0},
+        }

--- a/collectors/sustainability/openssf_scorecard.py
+++ b/collectors/sustainability/openssf_scorecard.py
@@ -1,0 +1,124 @@
+"""
+OpenSSF Scorecard Collector (CASS Report Section 4.2 — Sustainability)
+
+Fetches the OpenSSF Scorecard score for a GitHub repository via the free
+public API. Returns an overall score (0–10) plus per-check breakdowns.
+
+API docs: https://api.securityscorecards.dev
+"""
+
+import httpx
+import logging
+from typing import Any, Dict, List, Optional
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+_SCORECARD_API = "https://api.securityscorecards.dev/projects/github.com/{owner}/{repo}"
+
+
+class OpenSSFScorecardCollector(GitHubCollectorBase):
+    """Collects OpenSSF Scorecard metrics via the public Scorecard API."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        repo_url = package.get("repo_url", "")
+
+        owner_repo = self._extract_owner_repo(repo_url)
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {repo_url}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Fetching OpenSSF Scorecard for {owner}/{repo}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            return await self._fetch_scorecard(client, repo_name, owner, repo)
+
+    async def _fetch_scorecard(
+        self,
+        client: httpx.AsyncClient,
+        repo_name: str,
+        owner: str,
+        repo: str,
+    ) -> Dict[str, Any]:
+        url = _SCORECARD_API.format(owner=owner, repo=repo)
+        try:
+            response = await client.get(
+                url,
+                headers={"Accept": "application/json"},
+                follow_redirects=True,
+            )
+            if response.status_code == 404:
+                logger.info(f"No Scorecard found for {owner}/{repo}")
+                return self._no_scorecard_result(repo_name, owner, repo)
+            response.raise_for_status()
+            data = response.json()
+        except httpx.HTTPStatusError as e:
+            logger.warning(f"Scorecard API error for {owner}/{repo}: {e}")
+            return self._empty_result(repo_name)
+        except Exception as e:
+            logger.error(f"Scorecard fetch failed for {owner}/{repo}: {e}")
+            return self._empty_result(repo_name)
+
+        score: float = data.get("score", 0.0)
+        checks: List[Dict[str, Any]] = data.get("checks", [])
+
+        check_details = {
+            c["name"]: {
+                "score": c.get("score", 0),
+                "reason": c.get("reason", ""),
+                "documentation_url": c.get("documentation", {}).get("url", ""),
+            }
+            for c in checks
+        }
+
+        passed = sum(1 for c in checks if c.get("score", 0) >= 7)
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "scorecard_exists": True,
+            "score": round(score, 1),
+            "max_score": 10.0,
+            "percentage": round(score * 10, 1),
+            "checks_total": len(checks),
+            "checks_passed": passed,
+            "checks": check_details,
+            "scorecard_url": f"https://scorecard.dev/viewer/?uri=github.com/{owner}/{repo}",
+        }
+
+    def _no_scorecard_result(
+        self, repo_name: str, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "scorecard_exists": False,
+            "score": None,
+            "max_score": 10.0,
+            "percentage": None,
+            "checks_total": 0,
+            "checks_passed": 0,
+            "checks": {},
+            "scorecard_url": None,
+            "recommendation": f"Run Scorecard via: https://scorecard.dev/viewer/?uri=github.com/{owner}/{repo}",
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "scorecard_exists": False,
+            "score": None,
+            "max_score": 10.0,
+            "percentage": None,
+            "checks_total": 0,
+            "checks_passed": 0,
+            "checks": {},
+            "scorecard_url": None,
+        }

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -233,6 +233,14 @@ class MetricsOrchestrator:
         except Exception as e:
             logger.warning(f"OpenSSF badge collection failed for {package['name']}: {e}")
 
+        # OpenSSF Scorecard
+        try:
+            from collectors.sustainability.openssf_scorecard import OpenSSFScorecardCollector
+            collector = OpenSSFScorecardCollector(github_token=github_token)
+            sub_results["openssf_scorecard"] = await collector.collect(package)
+        except Exception as e:
+            logger.warning(f"OpenSSF Scorecard collection failed for {package['name']}: {e}")
+
         # Calculate combined sustainability score from available sub-collectors
         scores = []
         if "governance" in sub_results:
@@ -245,6 +253,10 @@ class MetricsOrchestrator:
             scores.append(sub_results["chaoss_activity"].get("overall_score", {}).get("score", 0))
         if "openssf_badge" in sub_results:
             scores.append(sub_results["openssf_badge"].get("overall_score", {}).get("score", 0))
+        if "openssf_scorecard" in sub_results:
+            pct = sub_results["openssf_scorecard"].get("percentage")
+            if pct is not None:
+                scores.append(pct)
 
         avg_score = sum(scores) / len(scores) if scores else 0.0
 
@@ -266,6 +278,7 @@ class MetricsOrchestrator:
 
         logger.info(f"Collecting Quality dimension for {package['name']}")
 
+        github_token = self.config.get("api_credentials", {}).get("github", {}).get("token", "")
         sub_results = {}
 
         # 4.3.2 Development Practices — CI/CD metrics
@@ -276,9 +289,19 @@ class MetricsOrchestrator:
         except Exception as e:
             logger.warning(f"CI/CD collection failed for {package['name']}: {e}")
 
+        # 4.3.5 Accessibility — portable build systems and containers
+        try:
+            from collectors.quality.accessibility import AccessibilityCollector
+            collector = AccessibilityCollector(github_token=github_token)
+            sub_results["accessibility"] = await collector.collect(package)
+        except Exception as e:
+            logger.warning(f"Accessibility collection failed for {package['name']}: {e}")
+
         scores = []
         if "ci_cd" in sub_results:
             scores.append(sub_results["ci_cd"].get("percentage", 0))
+        if "accessibility" in sub_results:
+            scores.append(sub_results["accessibility"].get("overall_score", {}).get("percentage", 0))
 
         avg_score = sum(scores) / len(scores) if scores else 0.0
 
@@ -516,6 +539,21 @@ class MetricsOrchestrator:
             gov_lines.append(
                 f'<p><strong>Score:</strong> {gov_score.get("score", 0)}/{gov_score.get("max_score", 3)}</p>'
             )
+        scorecard = sust.get("openssf_scorecard", {})
+        if scorecard and scorecard.get("scorecard_exists"):
+            score_val = scorecard.get("score")
+            sc_url = scorecard.get("scorecard_url", "")
+            checks_label = f'{scorecard.get("checks_passed", 0)}/{scorecard.get("checks_total", 0)} checks passed'
+            if sc_url and score_val is not None:
+                gov_lines.append(
+                    f'<p><strong>OpenSSF Scorecard:</strong> <a href="{sc_url}">{score_val}/10</a> ({checks_label})</p>'
+                )
+            elif score_val is not None:
+                gov_lines.append(
+                    f'<p><strong>OpenSSF Scorecard:</strong> {score_val}/10 ({checks_label})</p>'
+                )
+        elif scorecard and not scorecard.get("scorecard_exists") and scorecard.get("recommendation"):
+            gov_lines.append('<p><strong>OpenSSF Scorecard:</strong> Not available</p>')
         section_421_data = "\n".join(gov_lines) if governance else None
 
         # --- 4.2.2 Licensing and FAIR Compliance ---
@@ -602,6 +640,72 @@ class MetricsOrchestrator:
         else:
             section_423_data = None
 
+        qual = dims.get("quality", {}).get("sub_results", {})
+
+        # --- 4.3.2 Development Practices ---
+        ci_cd = qual.get("ci_cd", {})
+        openssf_badge = sust.get("openssf_badge", {})
+        section_432_lines = []
+        if ci_cd:
+            section_432_lines.append("<p><strong>CI/CD</strong></p>")
+            section_432_lines.append(
+                f'<p><strong>Score:</strong> {ci_cd.get("score", 0)}/{ci_cd.get("max_score", 6)}'
+                f' ({ci_cd.get("percentage", 0):.0f}%)</p>'
+            )
+            for key, val in ci_cd.get("details", []):
+                if key == "total_workflow_success_percentage" and val:
+                    section_432_lines.append(
+                        f'<p><strong>Workflow Success Rate:</strong> {val:.0f}%</p>'
+                    )
+        if openssf_badge:
+            section_432_lines.append("<p><strong>OpenSSF Best Practices Badge</strong></p>")
+            badge_status = openssf_badge.get("badge_status", {})
+            if openssf_badge.get("badge_exists"):
+                level = badge_status.get("level", "").capitalize()
+                badge_url = badge_status.get("url", "")
+                pct = badge_status.get("progress_percentage", 0)
+                if badge_url:
+                    section_432_lines.append(
+                        f'<p><strong>Badge:</strong> <a href="{badge_url}">{level}</a> ({pct:.0f}%)</p>'
+                    )
+                else:
+                    section_432_lines.append(f'<p><strong>Badge:</strong> {level} ({pct:.0f}%)</p>')
+            else:
+                section_432_lines.append('<p><strong>Badge:</strong> Not registered</p>')
+                overall = openssf_badge.get("overall_score", {})
+                if openssf_badge.get("assessment_method") == "repository_scan" and overall.get("percentage"):
+                    section_432_lines.append(
+                        f'<p><strong>Estimated readiness:</strong> {overall["percentage"]:.0f}%</p>'
+                    )
+                if openssf_badge.get("recommendation"):
+                    section_432_lines.append(f'<p>{openssf_badge["recommendation"]}</p>')
+        section_432_data = "\n".join(section_432_lines) if section_432_lines else None
+
+        # --- 4.3.5 Accessibility ---
+        accessibility = qual.get("accessibility", {})
+        if accessibility:
+            acc_lines = [
+                f'<p><strong>Container:</strong> {"Yes" if accessibility.get("has_container") else "No"}</p>',
+                f'<p><strong>Portable Build System:</strong> {"Yes" if accessibility.get("has_portable_build_system") else "No"}</p>',
+            ]
+            cats = accessibility.get("categories", {})
+            for cat_key, label in [
+                ("containers", "Containers"),
+                ("build_systems", "Build systems"),
+                ("python_packaging", "Python packaging"),
+            ]:
+                found = cats.get(cat_key, {}).get("found", [])
+                if found:
+                    acc_lines.append(f'<p><strong>{label}:</strong> {", ".join(found)}</p>')
+            overall = accessibility.get("overall_score", {})
+            acc_lines.append(
+                f'<p><strong>Score:</strong> {overall.get("score", 0)}/{overall.get("max_score", 0)}'
+                f' ({overall.get("percentage", 0):.0f}%)</p>'
+            )
+            section_435_data = "\n".join(acc_lines)
+        else:
+            section_435_data = None
+
         return {
             "package": repo_name,
             "impact": {
@@ -628,10 +732,10 @@ class MetricsOrchestrator:
             },
             "quality": {
                 "4.3.1": {"title": "Reliability and Robustness", "data": None},
-                "4.3.2": {"title": "Development Practices", "data": None},
+                "4.3.2": {"title": "Development Practices", "data": section_432_data},
                 "4.3.3": {"title": "Reproducibility", "data": None},
                 "4.3.4": {"title": "Usability", "data": None},
-                "4.3.5": {"title": "Accessibility", "data": None},
+                "4.3.5": {"title": "Accessibility", "data": section_435_data},
                 "4.3.6": {"title": "Maintainability and Understandability", "data": None},
                 "4.3.7": {"title": "Performance and Efficiency", "data": None},
             },

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -1,0 +1,76 @@
+"""Unit tests for AccessibilityCollector."""
+
+import asyncio
+import pytest
+from unittest.mock import patch
+from collectors.quality.accessibility import AccessibilityCollector
+
+
+@pytest.fixture
+def collector():
+    return AccessibilityCollector()
+
+
+class TestEmptyResult:
+    def test_structure(self, collector):
+        result = collector._empty_result("MyPkg")
+        assert result["package_name"] == "MyPkg"
+        assert result["has_container"] is False
+        assert result["has_portable_build_system"] is False
+        assert result["categories"] == {}
+
+
+class TestCollectInvalidUrl:
+    def test_invalid_url_returns_empty(self, collector):
+        result = asyncio.run(
+            collector.collect({"name": "Bad", "repo_url": "not-a-url"})
+        )
+        assert result["has_container"] is False
+        assert result["has_portable_build_system"] is False
+
+
+class TestScan:
+    def _run_scan(self, collector, found_paths):
+        async def mock_exists(client, owner, repo, path):
+            return path in found_paths
+
+        async def run():
+            import httpx
+            async with httpx.AsyncClient() as client:
+                with patch.object(collector, "_check_file_exists", side_effect=mock_exists):
+                    return await collector._scan(client, "MyPkg", "owner", "repo")
+
+        return asyncio.run(run())
+
+    def test_dockerfile_only(self, collector):
+        result = self._run_scan(collector, {"Dockerfile"})
+        assert result["has_container"] is True
+        assert result["categories"]["containers"]["found"] == ["Docker"]
+        assert result["categories"]["containers"]["count_found"] == 1
+
+    def test_cmake_and_dockerfile(self, collector):
+        result = self._run_scan(collector, {"Dockerfile", "CMakeLists.txt"})
+        assert result["has_container"] is True
+        assert result["has_portable_build_system"] is True
+        assert "CMake" in result["categories"]["build_systems"]["found"]
+
+    def test_nothing_found(self, collector):
+        result = self._run_scan(collector, set())
+        assert result["has_container"] is False
+        assert result["has_portable_build_system"] is False
+        assert result["overall_score"]["percentage"] == 0.0
+
+    def test_overall_score_increases_with_matches(self, collector):
+        none = self._run_scan(collector, set())
+        some = self._run_scan(collector, {"Dockerfile", "CMakeLists.txt", "pyproject.toml"})
+        assert some["overall_score"]["percentage"] > none["overall_score"]["percentage"]
+
+    def test_singularity_detected(self, collector):
+        result = self._run_scan(collector, {"Singularity"})
+        assert result["has_container"] is True
+        assert "Singularity / Apptainer" in result["categories"]["containers"]["found"]
+
+    def test_spack_detected(self, collector):
+        result = self._run_scan(collector, {"package.py"})
+        assert result["has_portable_build_system"] is True
+        assert "Spack" in result["categories"]["build_systems"]["found"]

--- a/tests/test_openssf_scorecard.py
+++ b/tests/test_openssf_scorecard.py
@@ -1,0 +1,82 @@
+"""Unit tests for OpenSSFScorecardCollector."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from collectors.sustainability.openssf_scorecard import OpenSSFScorecardCollector
+
+
+@pytest.fixture
+def collector():
+    return OpenSSFScorecardCollector()
+
+
+SAMPLE_SCORECARD = {
+    "score": 7.3,
+    "checks": [
+        {"name": "Branch-Protection", "score": 8, "reason": "...", "documentation": {"url": "https://example.com"}},
+        {"name": "CI-Tests",          "score": 10, "reason": "...", "documentation": {"url": "https://example.com"}},
+        {"name": "Code-Review",       "score": 3, "reason": "...", "documentation": {"url": "https://example.com"}},
+        {"name": "Dependency-Update-Tool", "score": 0, "reason": "...", "documentation": {"url": ""}},
+    ],
+}
+
+
+class TestEmptyResult:
+    def test_structure(self, collector):
+        result = collector._empty_result("MyPkg")
+        assert result["package_name"] == "MyPkg"
+        assert result["scorecard_exists"] is False
+        assert result["score"] is None
+        assert result["checks"] == {}
+
+
+class TestNoScorecardResult:
+    def test_structure(self, collector):
+        result = collector._no_scorecard_result("MyPkg", "owner", "repo")
+        assert result["scorecard_exists"] is False
+        assert result["score"] is None
+        assert "recommendation" in result
+
+
+class TestFetchScorecard:
+    def test_successful_fetch(self, collector):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = SAMPLE_SCORECARD
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        result = asyncio.run(
+            collector._fetch_scorecard(mock_client, "MyPkg", "owner", "repo")
+        )
+
+        assert result["scorecard_exists"] is True
+        assert result["score"] == 7.3
+        assert result["percentage"] == 73.0
+        assert result["checks_total"] == 4
+        # checks with score >= 7: Branch-Protection (8) and CI-Tests (10) = 2
+        assert result["checks_passed"] == 2
+        assert "Branch-Protection" in result["checks"]
+
+    def test_404_returns_no_scorecard(self, collector):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        result = asyncio.run(
+            collector._fetch_scorecard(mock_client, "MyPkg", "owner", "repo")
+        )
+        assert result["scorecard_exists"] is False
+        assert "recommendation" in result
+
+    def test_collect_invalid_url(self, collector):
+        result = asyncio.run(
+            collector.collect({"name": "Bad", "repo_url": "not-a-url"})
+        )
+        assert result["scorecard_exists"] is False
+        assert result["repository"] == "unknown"


### PR DESCRIPTION
## Summary

- **New collector** `collectors/sustainability/openssf_scorecard.py` — fetches the OpenSSF Scorecard score (0–10) and per-check breakdown from the free public `api.securityscorecards.dev` API; contributes to the sustainability dimension score
- **New collector** `collectors/quality/accessibility.py` — detects portable build systems (CMake, Spack, Conda, Autoconf, Makefile) and containers (Docker, Singularity/Apptainer) via GitHub Contents API; implements CASS Report §4.3.5
- **Dashboard output** — extends `_transform_for_dashboard` so four previously-null sections now produce populated HTML in `metrics.json`: §4.2.1 (+ OpenSSF Scorecard), §4.3.2 (CI/CD + OpenSSF Badge), §4.3.5 (Accessibility)
- **METRICS_ROADMAP.md** — new planning doc grouping all [corsa-center/metrics issues](https://github.com/corsa-center/metrics/issues) by ease of collection (Easy / Moderate / Hard) with implementation status

## Test plan

- [ ] `pytest` — 66 tests, all passing (13 new: `test_openssf_scorecard.py`, `test_accessibility.py`)
- [ ] Verify `metrics.json` output has non-null `data` for §4.2.1, §4.3.2, §4.3.5 after a dry-run collection