### PR TITLE
Add Reproducibility collector (§4.3.3)

### DIFF
--- a/collectors/quality/reproducibility.py
+++ b/collectors/quality/reproducibility.py
@@ -1,0 +1,245 @@
+"""
+Reproducibility Collector (CASS Report Section 4.3.3)
+
+Measures a project's ability to produce consistent, verifiable results by
+checking for:
+  - Containers       : Dockerfile, docker-compose, Singularity / Apptainer
+  - Dependency locks : pip lock files, Poetry, Conda-lock, Cargo, Go, etc.
+  - FAIR4RS metadata : CITATION.cff, codemeta.json, .zenodo.json
+  - Semantic versioning: whether GitHub releases follow semver (x.y.z)
+
+Semantic versioning is the one "Moderate" step — it requires a GitHub
+releases API call rather than a simple file-existence check.
+"""
+
+import asyncio
+import httpx
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+_SEMVER_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
+
+# File-presence categories: label -> candidate paths
+_FILE_CHECKS: Dict[str, Dict[str, List[str]]] = {
+    "containers": {
+        "Dockerfile": ["Dockerfile", "docker/Dockerfile", ".docker/Dockerfile"],
+        "docker-compose": ["docker-compose.yml", "docker-compose.yaml"],
+        "Singularity / Apptainer": [
+            "Singularity",
+            "singularity/Singularity",
+            "Apptainer",
+            "apptainer/Apptainer",
+        ],
+    },
+    "dependency_pinning": {
+        "pip lock (requirements.txt)": [
+            "requirements.txt",
+            "requirements/requirements.txt",
+        ],
+        "Poetry lock": ["poetry.lock"],
+        "Pipfile.lock": ["Pipfile.lock"],
+        "conda-lock": ["conda-lock.yml", "conda-lock.yaml"],
+        "package-lock.json": ["package-lock.json"],
+        "yarn.lock": ["yarn.lock"],
+        "Cargo.lock": ["Cargo.lock"],
+        "go.sum": ["go.sum"],
+        "uv.lock / pdm.lock": ["uv.lock", "pdm.lock"],
+    },
+    "fair4rs_metadata": {
+        "CITATION.cff": ["CITATION.cff"],
+        "codemeta.json": ["codemeta.json"],
+        "Zenodo metadata": [".zenodo.json", "zenodo.json"],
+    },
+}
+
+# Weights used to compute the overall percentage score.
+_WEIGHTS = {
+    "containers": 0.25,
+    "dependency_pinning": 0.35,
+    "fair4rs_metadata": 0.25,
+    "semantic_versioning": 0.15,
+}
+
+
+class ReproducibilityCollector(GitHubCollectorBase):
+    """Collects reproducibility indicators (CASS Report Section 4.3.3)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        repo_url = package.get("repo_url", "")
+
+        owner_repo = self._extract_owner_repo(repo_url)
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {repo_url}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Collecting reproducibility metrics for {owner}/{repo}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            file_results, semver = await asyncio.gather(
+                self._scan_files(client, owner, repo),
+                self._check_semantic_versioning(client, owner, repo),
+            )
+
+        categories = {**file_results, "semantic_versioning": semver}
+        overall = self._compute_overall(categories)
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "has_container": bool(categories["containers"]["found"]),
+            "has_dependency_pinning": bool(categories["dependency_pinning"]["found"]),
+            "has_fair4rs_metadata": bool(categories["fair4rs_metadata"]["found"]),
+            "uses_semantic_versioning": semver["uses_semver"],
+            "categories": categories,
+            "overall_score": overall,
+        }
+
+    # ------------------------------------------------------------------ #
+    # File scanning                                                        #
+    # ------------------------------------------------------------------ #
+
+    async def _scan_files(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        results: Dict[str, Any] = {}
+
+        for category, items in _FILE_CHECKS.items():
+            found: List[str] = []
+            missing: List[str] = []
+            details: Dict[str, Any] = {}
+
+            async def check_item(label: str, paths: List[str]) -> Tuple[str, str, bool]:
+                for path in paths:
+                    if await self._check_file_exists(client, owner, repo, path):
+                        return label, path, True
+                return label, paths[0], False
+
+            hits = await asyncio.gather(
+                *[check_item(label, paths) for label, paths in items.items()]
+            )
+
+            for label, matched_path, exists in hits:
+                if exists:
+                    found.append(label)
+                    details[label] = {
+                        "exists": True,
+                        "file": matched_path,
+                        "url": f"https://github.com/{owner}/{repo}/blob/main/{matched_path}",
+                    }
+                    logger.debug(f"  {category}/{label}: {matched_path}")
+                else:
+                    missing.append(label)
+                    details[label] = {"exists": False}
+
+            total = len(items)
+            results[category] = {
+                "found": found,
+                "missing": missing,
+                "details": details,
+                "count_found": len(found),
+                "count_total": total,
+                "percentage": round(len(found) / total * 100, 1) if total else 0.0,
+            }
+
+        return results
+
+    # ------------------------------------------------------------------ #
+    # Semantic versioning (GitHub releases API)                           #
+    # ------------------------------------------------------------------ #
+
+    async def _check_semantic_versioning(
+        self, client: httpx.AsyncClient, owner: str, repo: str, sample: int = 5
+    ) -> Dict[str, Any]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/releases"
+        try:
+            resp = await client.get(
+                url,
+                headers=self.github_headers,
+                params={"per_page": sample},
+            )
+            resp.raise_for_status()
+            releases = resp.json()
+        except Exception as e:
+            logger.warning(f"Could not fetch releases for {owner}/{repo}: {e}")
+            return {"uses_semver": False, "releases_checked": 0, "semver_count": 0, "example_tags": []}
+
+        if not releases:
+            # Fall back to tags if no formal releases exist
+            return await self._check_tags(client, owner, repo, sample)
+
+        tags = [r.get("tag_name", "") for r in releases]
+        semver_tags = [t for t in tags if _SEMVER_RE.match(t)]
+        uses_semver = len(semver_tags) > 0
+
+        return {
+            "uses_semver": uses_semver,
+            "releases_checked": len(tags),
+            "semver_count": len(semver_tags),
+            "example_tags": tags[:3],
+        }
+
+    async def _check_tags(
+        self, client: httpx.AsyncClient, owner: str, repo: str, sample: int
+    ) -> Dict[str, Any]:
+        url = f"https://api.github.com/repos/{owner}/{repo}/tags"
+        try:
+            resp = await client.get(
+                url,
+                headers=self.github_headers,
+                params={"per_page": sample},
+            )
+            resp.raise_for_status()
+            tags_data = resp.json()
+        except Exception as e:
+            logger.warning(f"Could not fetch tags for {owner}/{repo}: {e}")
+            return {"uses_semver": False, "releases_checked": 0, "semver_count": 0, "example_tags": []}
+
+        tags = [t.get("name", "") for t in tags_data]
+        semver_tags = [t for t in tags if _SEMVER_RE.match(t)]
+
+        return {
+            "uses_semver": len(semver_tags) > 0,
+            "releases_checked": len(tags),
+            "semver_count": len(semver_tags),
+            "example_tags": tags[:3],
+        }
+
+    # ------------------------------------------------------------------ #
+    # Scoring                                                              #
+    # ------------------------------------------------------------------ #
+
+    def _compute_overall(self, categories: Dict[str, Any]) -> Dict[str, Any]:
+        weighted = 0.0
+        for cat, weight in _WEIGHTS.items():
+            if cat == "semantic_versioning":
+                pct = 100.0 if categories[cat].get("uses_semver") else 0.0
+            else:
+                pct = categories[cat].get("percentage", 0.0)
+            weighted += pct * weight
+
+        return {
+            "score": round(weighted, 1),
+            "max_score": 100.0,
+            "percentage": round(weighted, 1),
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "has_container": False,
+            "has_dependency_pinning": False,
+            "has_fair4rs_metadata": False,
+            "uses_semantic_versioning": False,
+            "categories": {},
+            "overall_score": {"score": 0.0, "max_score": 100.0, "percentage": 0.0},
+        }

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -289,6 +289,14 @@ class MetricsOrchestrator:
         except Exception as e:
             logger.warning(f"CI/CD collection failed for {package['name']}: {e}")
 
+        # 4.3.3 Reproducibility — containers, lock files, FAIR4RS metadata, semver
+        try:
+            from collectors.quality.reproducibility import ReproducibilityCollector
+            collector = ReproducibilityCollector(github_token=github_token)
+            sub_results["reproducibility"] = await collector.collect(package)
+        except Exception as e:
+            logger.warning(f"Reproducibility collection failed for {package['name']}: {e}")
+
         # 4.3.5 Accessibility — portable build systems and containers
         try:
             from collectors.quality.accessibility import AccessibilityCollector
@@ -300,6 +308,8 @@ class MetricsOrchestrator:
         scores = []
         if "ci_cd" in sub_results:
             scores.append(sub_results["ci_cd"].get("percentage", 0))
+        if "reproducibility" in sub_results:
+            scores.append(sub_results["reproducibility"].get("overall_score", {}).get("percentage", 0))
         if "accessibility" in sub_results:
             scores.append(sub_results["accessibility"].get("overall_score", {}).get("percentage", 0))
 
@@ -642,6 +652,37 @@ class MetricsOrchestrator:
 
         qual = dims.get("quality", {}).get("sub_results", {})
 
+        # --- 4.3.3 Reproducibility ---
+        reproducibility = qual.get("reproducibility", {})
+        if reproducibility:
+            repr_lines = [
+                f'<p><strong>Container:</strong> {"Yes" if reproducibility.get("has_container") else "No"}</p>',
+                f'<p><strong>Dependency Pinning:</strong> {"Yes" if reproducibility.get("has_dependency_pinning") else "No"}</p>',
+                f'<p><strong>FAIR4RS Metadata:</strong> {"Yes" if reproducibility.get("has_fair4rs_metadata") else "No"}</p>',
+                f'<p><strong>Semantic Versioning:</strong> {"Yes" if reproducibility.get("uses_semantic_versioning") else "No"}</p>',
+            ]
+            cats = reproducibility.get("categories", {})
+            for cat_key, label in [
+                ("containers", "Containers"),
+                ("dependency_pinning", "Lock files"),
+                ("fair4rs_metadata", "FAIR4RS files"),
+            ]:
+                found = cats.get(cat_key, {}).get("found", [])
+                if found:
+                    repr_lines.append(f'<p><strong>{label}:</strong> {", ".join(found)}</p>')
+            semver = cats.get("semantic_versioning", {})
+            if semver.get("example_tags"):
+                repr_lines.append(
+                    f'<p><strong>Example tags:</strong> {", ".join(semver["example_tags"])}</p>'
+                )
+            overall = reproducibility.get("overall_score", {})
+            repr_lines.append(
+                f'<p><strong>Score:</strong> {overall.get("percentage", 0):.0f}/100</p>'
+            )
+            section_433_data = "\n".join(repr_lines)
+        else:
+            section_433_data = None
+
         # --- 4.3.2 Development Practices ---
         ci_cd = qual.get("ci_cd", {})
         openssf_badge = sust.get("openssf_badge", {})
@@ -733,7 +774,7 @@ class MetricsOrchestrator:
             "quality": {
                 "4.3.1": {"title": "Reliability and Robustness", "data": None},
                 "4.3.2": {"title": "Development Practices", "data": section_432_data},
-                "4.3.3": {"title": "Reproducibility", "data": None},
+                "4.3.3": {"title": "Reproducibility", "data": section_433_data},
                 "4.3.4": {"title": "Usability", "data": None},
                 "4.3.5": {"title": "Accessibility", "data": section_435_data},
                 "4.3.6": {"title": "Maintainability and Understandability", "data": None},
@@ -787,7 +828,7 @@ async def main():
         )
 
         logger.info(f"\n{'='*60}")
-        logger.info(f"Orchestration complete!")
+        logger.info("Orchestration complete!")
         logger.info(f"Processed {len(metrics)} packages")
         logger.info(f"{'='*60}\n")
 

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,150 @@
+"""Unit tests for ReproducibilityCollector."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from collectors.quality.reproducibility import ReproducibilityCollector
+
+
+@pytest.fixture
+def collector():
+    return ReproducibilityCollector()
+
+
+class TestEmptyResult:
+    def test_structure(self, collector):
+        result = collector._empty_result("MyPkg")
+        assert result["package_name"] == "MyPkg"
+        assert result["has_container"] is False
+        assert result["has_dependency_pinning"] is False
+        assert result["has_fair4rs_metadata"] is False
+        assert result["uses_semantic_versioning"] is False
+        assert result["overall_score"]["percentage"] == 0.0
+
+
+class TestCollectInvalidUrl:
+    def test_invalid_url_returns_empty(self, collector):
+        result = asyncio.run(
+            collector.collect({"name": "Bad", "repo_url": "not-a-url"})
+        )
+        assert result["has_container"] is False
+        assert result["repository"] == "unknown"
+
+
+class TestSemanticVersioning:
+    def _mock_releases(self, tags):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [{"tag_name": t} for t in tags]
+        mock_resp.raise_for_status = MagicMock()
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_resp)
+        return mock_client
+
+    def test_semver_tags_detected(self, collector):
+        client = self._mock_releases(["v1.2.3", "v1.2.2", "v1.2.1"])
+        result = asyncio.run(
+            collector._check_semantic_versioning(client, "owner", "repo")
+        )
+        assert result["uses_semver"] is True
+        assert result["semver_count"] == 3
+
+    def test_non_semver_tags(self, collector):
+        client = self._mock_releases(["release-2024", "latest", "nightly"])
+        result = asyncio.run(
+            collector._check_semantic_versioning(client, "owner", "repo")
+        )
+        assert result["uses_semver"] is False
+        assert result["semver_count"] == 0
+
+    def test_mixed_tags(self, collector):
+        client = self._mock_releases(["v2.0.0", "nightly", "v1.9.0"])
+        result = asyncio.run(
+            collector._check_semantic_versioning(client, "owner", "repo")
+        )
+        assert result["uses_semver"] is True
+        assert result["semver_count"] == 2
+
+    def test_no_releases_falls_back_to_tags(self, collector):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = []
+        mock_resp.raise_for_status = MagicMock()
+
+        tag_resp = MagicMock()
+        tag_resp.status_code = 200
+        tag_resp.json.return_value = [{"name": "v3.0.0"}]
+        tag_resp.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=[mock_resp, tag_resp])
+
+        result = asyncio.run(
+            collector._check_semantic_versioning(mock_client, "owner", "repo")
+        )
+        assert result["uses_semver"] is True
+
+
+class TestComputeOverall:
+    def test_all_present(self, collector):
+        categories = {
+            "containers":          {"found": ["Docker"], "percentage": 100.0},
+            "dependency_pinning":  {"found": ["poetry.lock"], "percentage": 100.0},
+            "fair4rs_metadata":    {"found": ["CITATION.cff"], "percentage": 100.0},
+            "semantic_versioning": {"uses_semver": True},
+        }
+        result = collector._compute_overall(categories)
+        assert result["percentage"] == 100.0
+
+    def test_nothing_present(self, collector):
+        categories = {
+            "containers":          {"found": [], "percentage": 0.0},
+            "dependency_pinning":  {"found": [], "percentage": 0.0},
+            "fair4rs_metadata":    {"found": [], "percentage": 0.0},
+            "semantic_versioning": {"uses_semver": False},
+        }
+        result = collector._compute_overall(categories)
+        assert result["percentage"] == 0.0
+
+    def test_partial_score(self, collector):
+        categories = {
+            "containers":          {"found": [], "percentage": 0.0},
+            "dependency_pinning":  {"found": [], "percentage": 0.0},
+            "fair4rs_metadata":    {"found": ["CITATION.cff"], "percentage": 100.0},
+            "semantic_versioning": {"uses_semver": True},
+        }
+        result = collector._compute_overall(categories)
+        # fair4rs 0.25 * 100 + semver 0.15 * 100 = 40.0
+        assert result["percentage"] == 40.0
+
+
+class TestScanFiles:
+    def _run_scan(self, collector, found_paths):
+        async def mock_exists(client, owner, repo, path):
+            return path in found_paths
+
+        async def run():
+            import httpx
+            async with httpx.AsyncClient() as client:
+                with patch.object(collector, "_check_file_exists", side_effect=mock_exists):
+                    return await collector._scan_files(client, "owner", "repo")
+
+        return asyncio.run(run())
+
+    def test_dockerfile_detected(self, collector):
+        result = self._run_scan(collector, {"Dockerfile"})
+        assert "Dockerfile" in result["containers"]["found"]
+
+    def test_poetry_lock_detected(self, collector):
+        result = self._run_scan(collector, {"poetry.lock"})
+        assert "Poetry lock" in result["dependency_pinning"]["found"]
+
+    def test_citation_cff_detected(self, collector):
+        result = self._run_scan(collector, {"CITATION.cff"})
+        assert "CITATION.cff" in result["fair4rs_metadata"]["found"]
+
+    def test_nothing_found(self, collector):
+        result = self._run_scan(collector, set())
+        for cat in ("containers", "dependency_pinning", "fair4rs_metadata"):
+            assert result[cat]["found"] == []
+            assert result[cat]["percentage"] == 0.0


### PR DESCRIPTION
## Summary

- **New collector** `collectors/quality/reproducibility.py` — implements CASS Report §4.3.3 by checking four categories:
  - **Containers**: Dockerfile, docker-compose, Singularity/Apptainer
  - **Dependency pinning**: Poetry lock, Pipfile.lock, conda-lock, Cargo.lock, go.sum, uv.lock, etc.
  - **FAIR4RS metadata**: CITATION.cff, codemeta.json, .zenodo.json
  - **Semantic versioning**: GitHub releases/tags API checked against semver pattern (the "Moderate" step that makes this more than simple file detection)
- Weighted score across all four categories (containers 25%, dependency pinning 35%, FAIR4RS 25%, semver 15%)
- **Dashboard output** — `_transform_for_dashboard` now renders §4.3.3 with non-null HTML in `metrics.json`
- **Tests**: 13 new tests covering all categories, semver detection, fallback to tags, and weighted scoring (79 total, all passing)

## Related issue

Closes corsa-center/metrics#19