### PR TITLE
Add Engagement collector (§4.2.4) and fix scheduled action crash

### DIFF
--- a/collectors/sustainability/engagement.py
+++ b/collectors/sustainability/engagement.py
@@ -1,0 +1,300 @@
+"""
+Engagement Collector (CASS Report Section 4.2.4)
+
+Measures how responsive and interactive a project is with its community by
+computing statistics from the GitHub issues and pull requests APIs:
+
+  - Median time to first non-bot response on issues
+  - Median issue close time (open → closed)
+  - Open-to-closed issue ratio (backlog signal)
+  - PR merge rate (accepted vs closed-without-merge)
+  - Median PR cycle time (open → merged)
+
+A sample of the most-recent 30 issues and 30 PRs is used to keep API
+calls manageable while still reflecting current project behaviour.
+"""
+
+import asyncio
+import httpx
+import logging
+import statistics
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional, Tuple
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+_SAMPLE = 30
+_MAINTAINER_ROLES = {"COLLABORATOR", "MEMBER", "OWNER"}
+_API = "https://api.github.com/repos/{owner}/{repo}"
+
+
+def _is_bot(login: str) -> bool:
+    return login.endswith("[bot]") or login.endswith("-bot")
+
+
+def _parse_dt(s: Optional[str]) -> Optional[datetime]:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _hours(a: Optional[datetime], b: Optional[datetime]) -> Optional[float]:
+    if a and b:
+        return abs((b - a).total_seconds()) / 3600
+    return None
+
+
+class EngagementCollector(GitHubCollectorBase):
+    """Collects engagement metrics from GitHub issues and PRs (§4.2.4)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        repo_url = package.get("repo_url", "")
+
+        owner_repo = self._extract_owner_repo(repo_url)
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {repo_url}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Collecting engagement metrics for {owner}/{repo}")
+
+        base = _API.format(owner=owner, repo=repo)
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            issues_raw, prs_raw, repo_info = await asyncio.gather(
+                self._fetch_issues(client, base),
+                self._fetch_prs(client, base),
+                self._fetch_repo_info(client, base),
+            )
+
+            # Fetch first comments for each issue concurrently (bot-filtered).
+            first_responses = await asyncio.gather(
+                *[self._first_response_hours(client, base, i) for i in issues_raw]
+            )
+
+        issue_stats = self._compute_issue_stats(issues_raw, list(first_responses))
+        pr_stats = self._compute_pr_stats(prs_raw)
+        backlog = self._compute_backlog(repo_info, issues_raw)
+        score = self._score(issue_stats, pr_stats, backlog)
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "issue_stats": issue_stats,
+            "pr_stats": pr_stats,
+            "backlog": backlog,
+            "overall_score": score,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Fetchers                                                             #
+    # ------------------------------------------------------------------ #
+
+    async def _fetch_issues(
+        self, client: httpx.AsyncClient, base: str
+    ) -> List[Dict]:
+        try:
+            resp = await client.get(
+                f"{base}/issues",
+                headers=self.github_headers,
+                params={"state": "all", "per_page": _SAMPLE, "sort": "updated", "direction": "desc"},
+            )
+            resp.raise_for_status()
+            # Exclude pull requests (GitHub issues API returns both)
+            return [i for i in resp.json() if "pull_request" not in i]
+        except Exception as e:
+            logger.warning(f"Issues fetch failed: {e}")
+            return []
+
+    async def _fetch_prs(
+        self, client: httpx.AsyncClient, base: str
+    ) -> List[Dict]:
+        try:
+            resp = await client.get(
+                f"{base}/pulls",
+                headers=self.github_headers,
+                params={"state": "closed", "per_page": _SAMPLE, "sort": "updated", "direction": "desc"},
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            logger.warning(f"PRs fetch failed: {e}")
+            return []
+
+    async def _fetch_repo_info(
+        self, client: httpx.AsyncClient, base: str
+    ) -> Dict:
+        try:
+            resp = await client.get(base, headers=self.github_headers)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as e:
+            logger.warning(f"Repo info fetch failed: {e}")
+            return {}
+
+    async def _first_response_hours(
+        self, client: httpx.AsyncClient, base: str, issue: Dict
+    ) -> Optional[float]:
+        """Return hours from issue creation to first non-bot comment, or None."""
+        if issue.get("comments", 0) == 0:
+            return None
+        number = issue["number"]
+        created = _parse_dt(issue.get("created_at"))
+        if not created:
+            return None
+        try:
+            resp = await client.get(
+                f"{base}/issues/{number}/comments",
+                headers=self.github_headers,
+                params={"per_page": 10},
+            )
+            resp.raise_for_status()
+            for comment in resp.json():
+                login = comment.get("user", {}).get("login", "")
+                if _is_bot(login):
+                    continue
+                first_comment_dt = _parse_dt(comment.get("created_at"))
+                return _hours(created, first_comment_dt)
+        except Exception as e:
+            logger.debug(f"Comment fetch failed for issue {number}: {e}")
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Statistics                                                           #
+    # ------------------------------------------------------------------ #
+
+    def _compute_issue_stats(
+        self, issues: List[Dict], response_times: List[Optional[float]]
+    ) -> Dict[str, Any]:
+        close_times = []
+        maintainer_first = 0
+        total_with_response = 0
+
+        for issue in issues:
+            created = _parse_dt(issue.get("created_at"))
+            closed = _parse_dt(issue.get("closed_at"))
+            h = _hours(created, closed)
+            if h is not None:
+                close_times.append(h)
+
+        valid_responses = [t for t in response_times if t is not None]
+
+        return {
+            "sample_size": len(issues),
+            "median_first_response_hours": round(statistics.median(valid_responses), 1) if valid_responses else None,
+            "median_close_time_hours": round(statistics.median(close_times), 1) if close_times else None,
+            "pct_with_response": round(len(valid_responses) / len(issues) * 100, 1) if issues else 0.0,
+        }
+
+    def _compute_pr_stats(self, prs: List[Dict]) -> Dict[str, Any]:
+        merged, closed_no_merge, cycle_times = 0, 0, []
+
+        for pr in prs:
+            if pr.get("merged_at"):
+                merged += 1
+                created = _parse_dt(pr.get("created_at"))
+                merged_at = _parse_dt(pr.get("merged_at"))
+                h = _hours(created, merged_at)
+                if h is not None:
+                    cycle_times.append(h)
+            else:
+                closed_no_merge += 1
+
+        total = merged + closed_no_merge
+        return {
+            "sample_size": total,
+            "merged": merged,
+            "closed_without_merge": closed_no_merge,
+            "merge_rate_pct": round(merged / total * 100, 1) if total else None,
+            "median_cycle_time_hours": round(statistics.median(cycle_times), 1) if cycle_times else None,
+        }
+
+    def _compute_backlog(self, repo_info: Dict, issues: List[Dict]) -> Dict[str, Any]:
+        open_count = repo_info.get("open_issues_count")  # includes open PRs
+        closed_in_sample = sum(1 for i in issues if i.get("state") == "closed")
+        open_in_sample = sum(1 for i in issues if i.get("state") == "open")
+        sample_ratio = (
+            round(open_in_sample / closed_in_sample, 2) if closed_in_sample else None
+        )
+        return {
+            "repo_open_issues": open_count,
+            "sample_open": open_in_sample,
+            "sample_closed": closed_in_sample,
+            "sample_open_to_closed_ratio": sample_ratio,
+        }
+
+    # ------------------------------------------------------------------ #
+    # Scoring (0–100)                                                      #
+    # ------------------------------------------------------------------ #
+
+    def _score(
+        self,
+        issue_stats: Dict[str, Any],
+        pr_stats: Dict[str, Any],
+        backlog: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        pts = 0
+
+        # First response time (25 pts)
+        frt = issue_stats.get("median_first_response_hours")
+        if frt is not None:
+            if frt < 24:
+                pts += 25
+            elif frt < 168:
+                pts += 15
+            elif frt < 720:
+                pts += 5
+
+        # Median close time (25 pts)
+        mct = issue_stats.get("median_close_time_hours")
+        if mct is not None:
+            if mct < 168:
+                pts += 25
+            elif mct < 720:
+                pts += 15
+            elif mct < 2160:
+                pts += 5
+
+        # PR merge rate (25 pts)
+        mrp = pr_stats.get("merge_rate_pct")
+        if mrp is not None:
+            if mrp > 75:
+                pts += 25
+            elif mrp > 50:
+                pts += 15
+            elif mrp > 25:
+                pts += 5
+
+        # Open/closed ratio (25 pts) — lower is better
+        ratio = backlog.get("sample_open_to_closed_ratio")
+        if ratio is not None:
+            if ratio < 0.5:
+                pts += 25
+            elif ratio < 1.0:
+                pts += 15
+            elif ratio < 2.0:
+                pts += 5
+
+        return {
+            "score": pts,
+            "max_score": 100,
+            "percentage": float(pts),
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "issue_stats": {},
+            "pr_stats": {},
+            "backlog": {},
+            "overall_score": {"score": 0, "max_score": 100, "percentage": 0.0},
+        }

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -114,6 +114,9 @@ class MetricsOrchestrator:
 
         software_list = []
         for repo_name, metadata in catalog.items():
+            if not isinstance(metadata, dict):
+                logger.warning(f"Skipping {repo_name}: metadata is not a dict ({type(metadata).__name__})")
+                continue
             # Apply filter if specified
             if filter_software and filter_software.lower() not in repo_name.lower():
                 continue
@@ -233,6 +236,14 @@ class MetricsOrchestrator:
         except Exception as e:
             logger.warning(f"OpenSSF badge collection failed for {package['name']}: {e}")
 
+        # 4.2.4 Engagement — issue/PR response times, open/close ratios
+        try:
+            from collectors.sustainability.engagement import EngagementCollector
+            collector = EngagementCollector(github_token=github_token)
+            sub_results["engagement"] = await collector.collect(package)
+        except Exception as e:
+            logger.warning(f"Engagement collection failed for {package['name']}: {e}")
+
         # OpenSSF Scorecard
         try:
             from collectors.sustainability.openssf_scorecard import OpenSSFScorecardCollector
@@ -253,6 +264,8 @@ class MetricsOrchestrator:
             scores.append(sub_results["chaoss_activity"].get("overall_score", {}).get("score", 0))
         if "openssf_badge" in sub_results:
             scores.append(sub_results["openssf_badge"].get("overall_score", {}).get("score", 0))
+        if "engagement" in sub_results:
+            scores.append(sub_results["engagement"].get("overall_score", {}).get("percentage", 0))
         if "openssf_scorecard" in sub_results:
             pct = sub_results["openssf_scorecard"].get("percentage")
             if pct is not None:
@@ -650,6 +663,36 @@ class MetricsOrchestrator:
         else:
             section_423_data = None
 
+        # --- 4.2.4 Engagement ---
+        engagement = sust.get("engagement", {})
+        if engagement:
+            issue_stats = engagement.get("issue_stats", {})
+            pr_stats = engagement.get("pr_stats", {})
+            backlog = engagement.get("backlog", {})
+            eng_lines = []
+            frt = issue_stats.get("median_first_response_hours")
+            if frt is not None:
+                eng_lines.append(f'<p><strong>Median First Response:</strong> {frt:.0f} hours</p>')
+            mct = issue_stats.get("median_close_time_hours")
+            if mct is not None:
+                eng_lines.append(f'<p><strong>Median Issue Close Time:</strong> {mct:.0f} hours</p>')
+            mrp = pr_stats.get("merge_rate_pct")
+            if mrp is not None:
+                eng_lines.append(f'<p><strong>PR Merge Rate:</strong> {mrp:.0f}%</p>')
+            mpr_ct = pr_stats.get("median_cycle_time_hours")
+            if mpr_ct is not None:
+                eng_lines.append(f'<p><strong>Median PR Cycle Time:</strong> {mpr_ct:.0f} hours</p>')
+            ratio = backlog.get("sample_open_to_closed_ratio")
+            if ratio is not None:
+                eng_lines.append(f'<p><strong>Open/Closed Issue Ratio:</strong> {ratio:.2f}</p>')
+            eng_score = engagement.get("overall_score", {})
+            eng_lines.append(
+                f'<p><strong>Score:</strong> {eng_score.get("score", 0)}/100</p>'
+            )
+            section_424_data = "\n".join(eng_lines) if eng_lines else None
+        else:
+            section_424_data = None
+
         qual = dims.get("quality", {}).get("sub_results", {})
 
         # --- 4.3.3 Reproducibility ---
@@ -763,7 +806,7 @@ class MetricsOrchestrator:
                     "data": section_422_data,
                 },
                 "4.2.3": {"title": "Active Maintenance", "data": section_423_data},
-                "4.2.4": {"title": "Engagement", "data": None},
+                "4.2.4": {"title": "Engagement", "data": section_424_data},
                 "4.2.5": {"title": "Outreach", "data": None},
                 "4.2.6": {"title": "Welcomeness", "data": None},
                 "4.2.7": {"title": "Collaboration", "data": None},

--- a/tests/test_engagement.py
+++ b/tests/test_engagement.py
@@ -1,0 +1,160 @@
+"""Unit tests for EngagementCollector."""
+
+import asyncio
+import pytest
+from collectors.sustainability.engagement import EngagementCollector, _is_bot, _hours, _parse_dt
+
+
+@pytest.fixture
+def collector():
+    return EngagementCollector()
+
+
+# ------------------------------------------------------------------ #
+# Helpers                                                              #
+# ------------------------------------------------------------------ #
+
+class TestHelpers:
+    def test_is_bot_github_actions(self):
+        assert _is_bot("github-actions[bot]") is True
+
+    def test_is_bot_renovate(self):
+        assert _is_bot("renovate-bot") is True
+
+    def test_is_bot_human(self):
+        assert _is_bot("octocat") is False
+
+    def test_parse_dt_z_suffix(self):
+        dt = _parse_dt("2024-01-15T10:00:00Z")
+        assert dt is not None
+        assert dt.year == 2024
+
+    def test_parse_dt_none(self):
+        assert _parse_dt(None) is None
+
+    def test_parse_dt_invalid(self):
+        assert _parse_dt("not-a-date") is None
+
+    def test_hours_calculation(self):
+        a = _parse_dt("2024-01-01T00:00:00Z")
+        b = _parse_dt("2024-01-01T06:00:00Z")
+        assert _hours(a, b) == 6.0
+
+    def test_hours_none_when_missing(self):
+        assert _hours(None, _parse_dt("2024-01-01T00:00:00Z")) is None
+
+
+# ------------------------------------------------------------------ #
+# Issue stats                                                          #
+# ------------------------------------------------------------------ #
+
+class TestComputeIssueStats:
+    def _make_issue(self, created, closed=None):
+        return {"created_at": created, "closed_at": closed, "number": 1, "comments": 0}
+
+    def test_median_close_time(self, collector):
+        issues = [
+            self._make_issue("2024-01-01T00:00:00Z", "2024-01-03T00:00:00Z"),  # 48h
+            self._make_issue("2024-01-01T00:00:00Z", "2024-01-05T00:00:00Z"),  # 96h
+        ]
+        result = collector._compute_issue_stats(issues, [None, None])
+        assert result["median_close_time_hours"] == 72.0
+
+    def test_response_times_included(self, collector):
+        issues = [self._make_issue("2024-01-01T00:00:00Z")]
+        result = collector._compute_issue_stats(issues, [12.0])
+        assert result["median_first_response_hours"] == 12.0
+
+    def test_none_responses_excluded(self, collector):
+        issues = [self._make_issue("2024-01-01T00:00:00Z")] * 3
+        result = collector._compute_issue_stats(issues, [None, None, None])
+        assert result["median_first_response_hours"] is None
+
+    def test_pct_with_response(self, collector):
+        issues = [self._make_issue("2024-01-01T00:00:00Z")] * 4
+        result = collector._compute_issue_stats(issues, [5.0, None, 10.0, None])
+        assert result["pct_with_response"] == 50.0
+
+
+# ------------------------------------------------------------------ #
+# PR stats                                                             #
+# ------------------------------------------------------------------ #
+
+class TestComputePrStats:
+    def _make_pr(self, created, merged_at=None):
+        return {"created_at": created, "merged_at": merged_at}
+
+    def test_merge_rate(self, collector):
+        prs = [
+            self._make_pr("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z"),
+            self._make_pr("2024-01-01T00:00:00Z", None),
+        ]
+        result = collector._compute_pr_stats(prs)
+        assert result["merge_rate_pct"] == 50.0
+        assert result["merged"] == 1
+        assert result["closed_without_merge"] == 1
+
+    def test_all_merged(self, collector):
+        prs = [self._make_pr("2024-01-01T00:00:00Z", "2024-01-03T00:00:00Z")] * 3
+        result = collector._compute_pr_stats(prs)
+        assert result["merge_rate_pct"] == 100.0
+
+    def test_empty_prs(self, collector):
+        result = collector._compute_pr_stats([])
+        assert result["merge_rate_pct"] is None
+        assert result["median_cycle_time_hours"] is None
+
+    def test_cycle_time(self, collector):
+        prs = [self._make_pr("2024-01-01T00:00:00Z", "2024-01-02T00:00:00Z")]  # 24h
+        result = collector._compute_pr_stats(prs)
+        assert result["median_cycle_time_hours"] == 24.0
+
+
+# ------------------------------------------------------------------ #
+# Scoring                                                              #
+# ------------------------------------------------------------------ #
+
+class TestScore:
+    def _score(self, collector, frt=None, mct=None, mrp=None, ratio=None):
+        return collector._score(
+            {"median_first_response_hours": frt, "median_close_time_hours": mct},
+            {"merge_rate_pct": mrp},
+            {"sample_open_to_closed_ratio": ratio},
+        )
+
+    def test_perfect_score(self, collector):
+        result = self._score(collector, frt=1.0, mct=24.0, mrp=80.0, ratio=0.2)
+        assert result["score"] == 100
+
+    def test_zero_score_when_all_none(self, collector):
+        result = self._score(collector)
+        assert result["score"] == 0
+
+    def test_fast_response_scores_25(self, collector):
+        result = self._score(collector, frt=1.0)
+        assert result["score"] == 25
+
+    def test_slow_response_scores_5(self, collector):
+        result = self._score(collector, frt=200.0)  # ~8 days
+        assert result["score"] == 5
+
+    def test_high_merge_rate_scores_25(self, collector):
+        result = self._score(collector, mrp=80.0)
+        assert result["score"] == 25
+
+    def test_low_backlog_scores_25(self, collector):
+        result = self._score(collector, ratio=0.3)
+        assert result["score"] == 25
+
+
+# ------------------------------------------------------------------ #
+# collect() with invalid URL                                           #
+# ------------------------------------------------------------------ #
+
+class TestCollectInvalidUrl:
+    def test_returns_empty(self, collector):
+        result = asyncio.run(
+            collector.collect({"name": "Bad", "repo_url": "not-a-url"})
+        )
+        assert result["repository"] == "unknown"
+        assert result["overall_score"]["score"] == 0


### PR DESCRIPTION
## Summary

- **New collector** `collectors/sustainability/engagement.py` — implements CASS Report §4.2.4 using a 30-item sample from the GitHub issues and pulls APIs:
  - Median time to first **non-bot** response on issues (filters `[bot]` and `-bot` logins)
  - Median issue close time
  - Open-to-closed issue ratio (backlog signal)
  - PR merge rate (accepted vs closed-without-merge)
  - Median PR cycle time (open → merged)
  - 0–100 score weighted across all four dimensions
- **Bug fix** — `prepare_software_list` now skips catalog entries where `metadata` is `None`, preventing the `AttributeError: 'NoneType' object has no attribute 'get'` crash that has been failing the scheduled collection action
- **Dashboard output** — `_transform_for_dashboard` now renders §4.2.4 with response time, close time, merge rate, cycle time, and backlog ratio
- **Tests**: 23 new tests covering helpers, stats computation, scoring, and invalid-URL handling (102 total, all passing)

## Related issues

Closes corsa-center/metrics#11
Fixes scheduled action crash: https://github.com/corsa-center/metrics/actions/runs/26702167782