### PR TITLE
Fix NoneType crash in scheduled collection action

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -114,6 +114,9 @@ class MetricsOrchestrator:
 
         software_list = []
         for repo_name, metadata in catalog.items():
+            if not isinstance(metadata, dict):
+                logger.warning(f"Skipping {repo_name}: metadata is not a dict ({type(metadata).__name__})")
+                continue
             # Apply filter if specified
             if filter_software and filter_software.lower() not in repo_name.lower():
                 continue


### PR DESCRIPTION
## Problem

The scheduled collection action has been failing on every run with:

```
AttributeError: 'NoneType' object has no attribute 'get'
  File "orchestrator.py", line 130, in prepare_software_list
    "license": metadata.get("licenseInfo", {}).get("spdxId"),
```

Some entries in `intReposInfo.json` have `null` values, causing `metadata.get(...)` to crash immediately.

Seen in:
- https://github.com/corsa-center/metrics/actions/runs/26702167782
- https://github.com/corsa-center/metrics/actions/runs/26851040620

## Fix

One guard in `prepare_software_list` — skip any catalog entry where `metadata` is not a dict and log a warning so the bad entry is visible.

## Notes

This is a minimal hotfix from `main`. The same fix is also included in PR #33 (Engagement collector), but that PR contains unreviewed feature work. This PR targets `main` directly so the scheduler can be unblocked immediately.