### PR TITLE
Fix null licenseInfo/primaryLanguage crash in prepare_software_list

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -127,10 +127,8 @@ class MetricsOrchestrator:
                 "repo_url": metadata.get("url", f"https://github.com/{repo_name}"),
                 "description": metadata.get("description", ""),
                 "homepage": metadata.get("homepageUrl"),
-                "license": metadata.get("licenseInfo", {}).get("spdxId"),
-                "primary_language": metadata.get("primaryLanguage", {}).get("name")
-                if metadata.get("primaryLanguage")
-                else None,
+                "license": (metadata.get("licenseInfo") or {}).get("spdxId"),
+                "primary_language": (metadata.get("primaryLanguage") or {}).get("name"),
             }
             software_list.append(package)
 
@@ -652,7 +650,7 @@ async def main():
         )
 
         logger.info(f"\n{'='*60}")
-        logger.info(f"Orchestration complete!")
+        logger.info("Orchestration complete!")
         logger.info(f"Processed {len(metrics)} packages")
         logger.info(f"{'='*60}\n")
 


### PR DESCRIPTION
## Problem

After merging #34, the action still crashes:

```
AttributeError: 'NoneType' object has no attribute 'get'
  File "orchestrator.py", line 130, in prepare_software_list
    "license": metadata.get("licenseInfo", {}).get("spdxId"),
```

`metadata` is a dict (the `isinstance` guard from #34 passed), but `licenseInfo` is present in the dict with an explicit `null` value. `dict.get(key, default)` only returns `default` when the key is **absent** — if it exists as `null`, it returns `None`, and `.get("spdxId")` then crashes.

## Fix

Use `(metadata.get("licenseInfo") or {})` so that both absent and explicitly-null values are treated as empty dicts. Same treatment applied to `primaryLanguage`.