### PR TITLE
Add 4.2.5/4.2.8/4.2.9/4.2.10 sections and the 4.3.2 tooling sub-metrics

### DIFF
--- a/METRICS_CATALOG.md
+++ b/METRICS_CATALOG.md
@@ -1,0 +1,392 @@
+# Metrics Catalog
+
+Every metric the framework collects, organized by the section numbering of the
+**CASS Sustainability Metrics Report v3**. Each section lists the sub-metrics
+named by the report, whether the framework fills them today, and where the data
+comes from.
+
+The report defines three dimensions — **4.1 Impact**, **4.2 Sustainability**,
+**4.3 Quality** — and 19 sections beneath them. Sub-metric names below are the
+report's own; they are also the keys used by the `package_config/` override
+files and by `SECTION_SUBMETRICS` in [`orchestrator.py`](orchestrator.py).
+
+**Legend:** ✅ collected · 🔲 rendered as "Not yet collected" · ⬜ whole section
+is a stub
+
+---
+
+## Coverage at a glance
+
+| Section | Title | Filled |
+|---|---|---|
+| 4.1.1 | Software Citation and Adoption | 7/7 |
+| 4.1.2 | Field Research Impact | ⬜ 0/3 |
+| 4.2.1 | CoC, Governance, and Contributor Guidelines | 3/5 |
+| 4.2.2 | Open-Source Licensing and FAIR Compliance | 2/5 |
+| 4.2.3 | Active Maintenance | 4/6 |
+| 4.2.4 | Engagement | 4/7 |
+| 4.2.5 | Outreach | 5/8 |
+| 4.2.6 | Welcomeness | ⬜ 0/7 |
+| 4.2.7 | Collaboration | ⬜ 0/5 |
+| 4.2.8 | Financial Sustainability | 4/5 |
+| 4.2.9 | Institutional & Organizational Support | 1/5 |
+| 4.2.10 | Project Longevity and Community Health | 5/5 |
+| 4.3.1 | Reliability and Robustness | 2/5 |
+| 4.3.2 | Development Practices | 5/5 |
+| 4.3.3 | Reproducibility | 4/5 |
+| 4.3.4 | Usability | ⬜ 0/5 |
+| 4.3.5 | Accessibility | 2/5 |
+| 4.3.6 | Maintainability and Understandability | 1/5 |
+| 4.3.7 | Performance and Efficiency | ⬜ 0/10 |
+
+A stub section renders nothing unless the package's `package_config/` file
+supplies overrides, in which case it renders those values against a 0/N score.
+
+---
+
+## 4.1 Impact
+
+### 4.1.1 Software Citation and Adoption
+**Collector:** [`collectors/impact/citation.py`](collectors/impact/citation.py)
+
+This section renders its own labels rather than the report's five sub-metric
+names, because the underlying sources return directly comparable counts.
+
+| Rendered metric | Status | Source |
+|---|---|---|
+| Formal Citations | ✅ | Semantic Scholar, OpenAlex |
+| Informal Mentions | ✅ | Semantic Scholar |
+| Dependent Packages | ✅ | GitHub API |
+| DOI Resolutions | ✅ | Zenodo |
+| GitHub Stars | ✅ | GitHub API |
+| GitHub Forks | ✅ | GitHub API |
+| Citation Score | ✅ | computed |
+
+### 4.1.2 Field Research Impact
+**Collector:** none — ⬜ stub
+
+AI-Enhanced Publication Analysis · Comprehensive Institutional Tracking ·
+Impact Narrative Extraction. All three need LLM analysis of scientific
+literature plus facility web scraping; see the "Hard" tier in
+[METRICS_ROADMAP.md](METRICS_ROADMAP.md).
+
+---
+
+## 4.2 Sustainability
+
+### 4.2.1 Codes of Conduct, Governance, and Contributor Guidelines
+**Collectors:** [`community_health.py`](collectors/sustainability/community_health.py),
+[`chaoss_governance.py`](collectors/sustainability/chaoss_governance.py),
+[`openssf_badge.py`](collectors/sustainability/openssf_badge.py),
+[`openssf_scorecard.py`](collectors/sustainability/openssf_scorecard.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Enhanced Document Detection | ✅ | CODE_OF_CONDUCT / GOVERNANCE / CONTRIBUTING file detection |
+| Governance Keyword Analysis | 🔲 | — |
+| OpenSSF Badge Integration | ✅ | `bestpractices.dev`, level + percentage. **Substituted** by an *OpenSSF Scorecard* row (`api.securityscorecards.dev`, with a per-check breakdown of failing checks) whenever scorecard data exists, so the section is always 5 rows |
+| CHAOSS Governance Metrics | ✅ | [`chaoss_governance.py`](collectors/sustainability/chaoss_governance.py) — weighted 0–100 health score, passing at ≥60, with a per-category breakdown (popularity, docs, time-to-close, issue age, PR closure ratio, release frequency, issue inclusivity) |
+| Governance Effectiveness Assessment | 🔲 | — |
+
+> `community_health.py` is named for the report's older phrasing but is the
+> **4.2.1** collector: it detects governance documents. It has nothing to do
+> with 4.2.10.
+
+### 4.2.2 Open-Source Licensing and FAIR Compliance
+**Collector:** [`licensing.py`](collectors/sustainability/licensing.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Enhanced License Detection | ✅ | GitHub License API, SPDX identifier |
+| Automated FAIR4RS Assessment | 🔲 | — |
+| OSI License Validation | ✅ | SPDX / OSI approval list |
+| License Exception Handling | 🔲 | — |
+| FAIR Metadata Assessment | 🔲 | — |
+
+### 4.2.3 Active Maintenance
+**Collector:** [`active_maintenance.py`](collectors/sustainability/active_maintenance.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Commit Activity Pattern Analysis | ✅ | `/stats/participation`, 52-week series |
+| Maintenance Mode Indicator Detection | ✅ | `archived` flag + description keywords |
+| Activity Trend Monitoring | ✅ | last 13 weeks vs previous 13 |
+| Release Pattern Assessment | ✅ | `/releases`, releases in last year |
+| Multi-Channel Communication Activity | 🔲 | — |
+| Contributor Abandonment Forecasting | 🔲 | — |
+
+### 4.2.4 Engagement
+**Collector:** [`engagement.py`](collectors/sustainability/engagement.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Response Time Tracking | ✅ | `/issues`, time to first response |
+| Issue Resolution Analysis | ✅ | `/issues`, close rate |
+| Pull Request Flow Assessment | ✅ | `/pulls`, median cycle time |
+| Support Request Closure Analysis | ✅ | `/issues` |
+| Engagement Quality Metrics | 🔲 | — |
+| Communication Pattern Analysis | 🔲 | — |
+| Community Participation Assessment | 🔲 | — |
+
+### 4.2.5 Outreach
+**Collector:** [`outreach.py`](collectors/sustainability/outreach.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| New Contributor Tracking | ✅ | contributors whose all-time count is fully inside the last 365 days |
+| Contributor Retention Analysis | ✅ | share of those newcomers with ≥2 commits; passes at ≥50% |
+| Contributor Lifecycle Mapping | ✅ | one-time (1) / casual (2–4) / repeat (5+) buckets from `/contributors` |
+| Contribution Type Diversity | 🔲 | non-code contributions aren't recorded in the repo |
+| Good First Issue Effectiveness | ✅ | search API counts for `good first issue`, `help wanted`, `newcomer`; passes on ≥1 **open** |
+| External Event Participation | 🔲 | needs conference programmes |
+| Training Material Integration | 🔲 | needs course syllabi |
+| Onboarding Infrastructure Assessment | ✅ | CONTRIBUTING, issue/PR templates, getting-started guide; passes at 3/4 |
+
+> "New" is inferred by comparing each author's all-time contribution count
+> against their commits in the window, rather than walking the whole log to find
+> each first commit. Cheap and accurate for normal repos; it misses anyone whose
+> recent commits exceed the 10-page pagination cap.
+
+### 4.2.6 Welcomeness
+**Collector:** none — ⬜ stub
+
+CHAOSS Community Experience Metrics · Response Quality and Tone Analysis ·
+Communication Sentiment Analysis · Contributor Journey Mapping · Language and
+Communication Review · Leadership Role Representation · Decision-Making
+Visibility.
+
+### 4.2.7 Collaboration
+**Collector:** none — ⬜ stub
+
+Advanced Dependency Analysis · Cross-project Reference Detection ·
+Interoperability Assessment · Collaboration Network Analysis · Standards
+Compliance Tracking.
+
+### 4.2.8 Financial Sustainability
+**Collector:** [`funding.py`](collectors/sustainability/funding.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Enhanced Funding Documentation Analysis | ✅ | FUNDING.yml / funding.json, plus DOE/NSF/NIH award numbers in the README |
+| Institutional Affiliation Tracking | ✅ | `company` field of the top 25 contributors; passes at ≥3 distinct orgs |
+| NIH R50 Award Tracking | 🔲 | NIH RePORTER API is public and unauthenticated — a Tier 2 win, not yet wired |
+| Corporate Sponsorship Detection | ✅ | declared funding platforms + organization-owned repository |
+| Funding Portfolio Analysis | ✅ | count of distinct platforms + award references; passes at ≥2 |
+
+> Contributor affiliations are folded onto a canonical key, so "The HDF Group",
+> "HDFGroup" and "The HDFgroup" count as one organization. Without that the
+> free-text `company` field inflates the diversity figure — HDF5 read as 5
+> organizations instead of its actual 3.
+
+### 4.2.9 Institutional & Organizational Support
+**Collector:** [`funding.py`](collectors/sustainability/funding.py) — shares
+4.2.8's contributor-affiliation pass rather than fetching it twice.
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| RSE Position Detection | 🔲 | needs LinkedIn / institutional directories |
+| Institutional Support Tracking | ✅ | distinct organizations backing the top contributors |
+| Career Development Indicators | 🔲 | not visible from the repository |
+| NIH R50 Award Integration | 🔲 | NIH RePORTER, as for 4.2.8 |
+| Institutional Policy Analysis | 🔲 | not visible from the repository |
+
+### 4.2.10 Project Longevity and Community Health
+**Collector:** none of its own — derived in `_transform_for_dashboard`
+([`orchestrator.py`](orchestrator.py)) from data `active_maintenance.py`
+already fetched for 4.2.3. Costs **zero additional API calls**.
+
+| Sub-metric | Status | Derivation |
+|---|---|---|
+| Comprehensive Activity Analysis | ✅ | commits, releases and sustained activity as 3 dimensions; ≥2 passes |
+| Contributor Viability Assessment | ✅ | bus factor ≥ 3 (same threshold as 4.2.3 and 4.3.6) |
+| Maintenance Mode Detection | ✅ | archived flag, description keywords, >365 days without a push |
+| Community Health Trends | ✅ | 52-week commit trend (increasing / stable passes) |
+| Project Lifecycle Assessment | ✅ | project age × current release activity → Emerging / Growing / Mature / Legacy / Retired |
+
+**Project age reports both dates**, because for a migrated project they differ
+by decades and neither alone is honest:
+
+- **First commit** — the age of the code history. Found via the `rel="last"`
+  Link header on `/commits?per_page=1`, so it costs two requests regardless of
+  history size. Reset by a history rewrite.
+- **GitHub repository creation** — `created_at`. Understates any project that
+  moved to GitHub from another VCS.
+
+Lifecycle staging uses the longer of the two. HDF5 renders as
+`first commit 1997-07-30 (29.1 yrs); GitHub repo created 2020-04-24 (6.3 yrs)`
+— a 23-year gap. A repo created empty has its first commit land *after*
+creation (zfp, by one day), so the repo date is sometimes the longer span.
+
+---
+
+## 4.3 Quality
+
+### 4.3.1 Reliability and Robustness
+**Collectors:** [`test_coverage.py`](collectors/quality/test_coverage.py),
+[`static_analysis.py`](collectors/quality/static_analysis.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Advanced Static Analysis | 🔲 | — |
+| Enhanced Security Analysis | ✅ | CodeQL workflow presence |
+| CERT Guidelines Compliance | 🔲 | — |
+| Test Coverage Excellence | ✅ | Codecov v2 public API; passes at ≥80% |
+| Reliability Trend Analysis | 🔲 | — |
+
+Codecov's `api.codecov.io/api/v2/github/{owner}/repos/{repo}/` is public and
+unauthenticated for public repos. Repos with no active Codecov integration
+render "No Codecov data found" rather than a number. Coveralls was evaluated
+and rejected — its public JSON endpoint returns HTTP 403 to non-browser clients.
+
+### 4.3.2 Development Practices
+**Collectors:** [`ci_cd.py`](collectors/quality/development_practices/ci_cd.py),
+[`dev_tooling.py`](collectors/quality/development_practices/dev_tooling.py),
+[`openssf_badge.py`](collectors/sustainability/openssf_badge.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| CI/CD Effectiveness Assessment | ✅ | `.github/workflows/` parsing + run status |
+| Testing Framework Excellence | ✅ | test directories, CTest, pytest config, vendored frameworks; passes at 2/4 |
+| Code Review Quality Analysis | ✅ | share of the last 50 merged PRs with ≥1 review; passes at ≥70% |
+| Development Tool Integration | ✅ | pre-commit, formatter, linter, Dependabot/Renovate configs; passes at 2/4 |
+| Community Contribution Facilitation | ✅ | OpenSSF Best Practices badge as proxy |
+
+### 4.3.3 Reproducibility
+**Collector:** [`reproducibility.py`](collectors/quality/reproducibility.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| FAIR4RS Compliance Assessment | ✅ | CITATION.cff, codemeta.json, `.zenodo.json` |
+| Containerization Excellence | ✅ | Dockerfile, Singularity/Apptainer definitions |
+| Version Control Best Practices | ✅ | semantic versioning in `/tags` |
+| Environment Management | ✅ | dependency pinning: `requirements.txt`, `poetry.lock`, `conda-lock.yml`, `package-lock.json`, `Cargo.lock`, `uv.lock` |
+| Reproducibility Documentation | 🔲 | — |
+
+### 4.3.4 Usability
+**Collector:** none — ⬜ stub
+
+User Experience Assessment · Documentation Completeness Analysis ·
+Accessibility Feature Detection · Installation Success Tracking · Usage
+Analytics Integration.
+
+### 4.3.5 Accessibility
+**Collector:** [`accessibility.py`](collectors/quality/accessibility.py)
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Portable Build System Detection | ✅ | CMake, Autotools, Meson, Spack recipe, Conda |
+| Container Availability Assessment | ✅ | Dockerfile, Singularity/Apptainer |
+| Architecture Compatibility Analysis | 🔲 | — |
+| Platform Documentation Evaluation | 🔲 | — |
+| Deployment Environment Testing | 🔲 | — |
+
+### 4.3.6 Maintainability and Understandability
+**Collector:** none of its own — bus factor reused from
+`active_maintenance.py` via `_transform_for_dashboard`.
+
+| Sub-metric | Status | Source |
+|---|---|---|
+| Advanced Complexity Analysis | 🔲 | — |
+| Code Quality Assessment | 🔲 | — |
+| Documentation Quality Evaluation | 🔲 | — |
+| Knowledge Distribution Analysis | ✅ | bus factor ≥ 3, plus top-contributor share |
+| Refactoring and Evolution Tracking | 🔲 | — |
+
+### 4.3.7 Performance and Efficiency
+**Collector:** none — ⬜ stub
+
+Performance Benchmarking Integration · Environmental Impact Assessment ·
+Resource Utilization Analysis · Scalability Assessment · Optimization Practice
+Evaluation · Memory Efficiency Analysis · I/O Performance Profiling ·
+Algorithmic Complexity Assessment · Power Measurement Integration ·
+Performance Portability Assessment.
+
+All ten require running benchmarks on target hardware, profiling
+(Valgrind/Darshan/RAPL/NVML), or domain expertise to interpret.
+
+---
+
+## Scoring
+
+Each section reports `Score: n/N`, where `N` is the number of sub-metrics the
+report defines for it and `n` is how many currently pass. Section scores roll up
+into three dimension scores, which combine into an overall score using the
+weights in [`config/orchestrator.yaml`](config/orchestrator.yaml):
+
+```yaml
+metric_weights:
+  impact: 0.33
+  sustainability: 0.34
+  quality: 0.33
+```
+
+Sections with no collector contribute 0 and are excluded from their dimension's
+average rather than dragging it down.
+
+---
+
+## Configuration
+
+Collectors are toggled per **dimension** in
+[`config/orchestrator.yaml`](config/orchestrator.yaml):
+
+```yaml
+collectors:
+  impact: true          # 4.1
+  sustainability: true  # 4.2
+  quality: true         # 4.3
+```
+
+Individual sub-collectors are toggled within a dimension:
+
+```yaml
+sustainability_collectors:
+  community_health: true    # 4.2.1 governance docs
+  chaoss_activity: true     # 4.2.1 CHAOSS Governance Metrics
+  openssf_scorecard: true   # 4.2.1 OpenSSF Scorecard
+  openssf_badge: true       # 4.2.1 + 4.3.2
+  licensing: true           # 4.2.2
+  active_maintenance: true  # 4.2.3, and 4.2.10 + 4.3.6 derive from it
+  engagement: true          # 4.2.4
+  outreach: true            # 4.2.5
+  funding: true             # 4.2.8 + 4.2.9
+
+quality_collectors:
+  test_coverage: true       # 4.3.1
+  static_analysis: true     # 4.3.1
+  ci_cd: true               # 4.3.2
+  dev_tooling: true         # 4.3.2
+  reproducibility: true     # 4.3.3
+  accessibility: true       # 4.3.5
+```
+
+Omitted keys default to `true`, so deleting a block runs everything. Disabling
+a sub-collector skips its API calls and drops it from the dimension average
+rather than scoring it zero; the sections it feeds render "Not yet collected".
+Turning off `active_maintenance` also empties 4.2.10 and 4.3.6, which are
+derived from it.
+
+Per-package overrides for sub-metrics that are genuinely N/A live in
+`package_config/<owner>_<repo>.yaml`; keys are the exact sub-metric labels from
+this catalog. See [PLACEHOLDER_GUIDE.md](PLACEHOLDER_GUIDE.md).
+
+---
+
+## API sources
+
+| Service | Auth | Used for |
+|---|---|---|
+| GitHub REST API | token | most sections |
+| Semantic Scholar | optional key | 4.1.1 citations, mentions |
+| OpenAlex | polite-pool email | 4.1.1 citations |
+| Zenodo | none | 4.1.1 DOI resolutions |
+| OpenSSF Scorecard | none | 4.2.1 |
+| OpenSSF Best Practices | none | 4.2.1, 4.3.2 |
+| Codecov v2 | none | 4.3.1 test coverage |
+
+---
+
+## Contact
+
+- CORSA Dashboard: info@corsa.center
+- Issues: [corsa-center/metrics](https://github.com/corsa-center/metrics/issues)

--- a/METRICS_ROADMAP.md
+++ b/METRICS_ROADMAP.md
@@ -24,11 +24,11 @@ No significant post-processing required.
 
 | Issue | Metric | Collector | Status |
 |-------|--------|-----------|--------|
-| [#8](https://github.com/corsa-center/metrics/issues/8) | 4.2.1 CoC, Governance & Contributor Guidelines | `collectors/sustainability/chaoss_governance.py` | ✅ Done |
+| [#8](https://github.com/corsa-center/metrics/issues/8) | 4.2.1 CoC, Governance & Contributor Guidelines | `collectors/sustainability/community_health.py` + `chaoss_governance.py` | ✅ Done (partial — docs, CHAOSS, OpenSSF badge/scorecard; keyword & effectiveness analysis TBD) |
 | [#9](https://github.com/corsa-center/metrics/issues/9) | 4.2.2 Open-Source Licensing & FAIR Compliance | `collectors/sustainability/licensing.py` | ✅ Done |
 | [#10](https://github.com/corsa-center/metrics/issues/10) | 4.2.3 Active Maintenance | `collectors/sustainability/active_maintenance.py` | ✅ Done |
-| [#16](https://github.com/corsa-center/metrics/issues/16) | 4.2.10 Project Longevity & Community Health | `collectors/sustainability/community_health.py` | ✅ Done |
-| [#18](https://github.com/corsa-center/metrics/issues/18) | 4.3.2 Development Practices (CI/CD) | `collectors/quality/development_practices/ci_cd.py` | ✅ Done |
+| [#16](https://github.com/corsa-center/metrics/issues/16) | 4.2.10 Project Longevity & Community Health | `orchestrator.py` (derived from `active_maintenance.py`) | ✅ Done |
+| [#18](https://github.com/corsa-center/metrics/issues/18) | 4.3.2 Development Practices | `ci_cd.py` + `dev_tooling.py` | ✅ Done (5/5) |
 | [#21](https://github.com/corsa-center/metrics/issues/21) | 4.3.5 Accessibility (portable build systems) | `collectors/quality/accessibility.py` | ✅ Done |
 | — | **OpenSSF Best Practices Badge** (Quality) | `collectors/sustainability/openssf_badge.py` | ✅ Done |
 | — | **OpenSSF Scorecard** (Sustainability) | `collectors/sustainability/openssf_scorecard.py` | ✅ Done |
@@ -39,6 +39,12 @@ No significant post-processing required.
 
 - All data is a single API call or file-existence check — no ML, no scraping, no
   domain expertise required.
+- **4.2.10** has no collector of its own. All five of its sub-metrics are
+  re-derived in `_transform_for_dashboard` from data `ActiveMaintenanceCollector`
+  already fetches for 4.2.3, so the section costs zero additional API calls.
+  Note that `community_health.py`, despite its name, is the **4.2.1** collector
+  (Code of Conduct / GOVERNANCE / CONTRIBUTING file detection) and is not
+  involved in 4.2.10.
 - The three recommended new metrics are the lightest of all: each returns a
   pre-computed score from a free public API.
   - **OpenSSF Scorecard**: 3 projects (ADIOS, Viskores, PnetCDF) already report
@@ -67,11 +73,11 @@ static analysis tool runs, or non-trivial content parsing.
 |-------|--------|-----------|--------|
 | [#6](https://github.com/corsa-center/metrics/issues/6) | 4.1.1 Software Citation & Adoption | `collectors/impact/citation.py` | ✅ Done (partial — CITATION.cff/DOI; advanced deps TBD) |
 | [#11](https://github.com/corsa-center/metrics/issues/11) | 4.2.4 Engagement | `collectors/sustainability/engagement.py` | ✅ Done |
-| [#12](https://github.com/corsa-center/metrics/issues/12) | 4.2.5 Outreach | — | 🔲 Todo |
+| [#12](https://github.com/corsa-center/metrics/issues/12) | 4.2.5 Outreach | `collectors/sustainability/outreach.py` | ✅ Done (partial — 5/8; event & training data not in the repo) |
 | [#17](https://github.com/corsa-center/metrics/issues/17) | 4.3.1 Reliability & Robustness | `collectors/quality/test_coverage.py` | ✅ Done (partial — Test Coverage Excellence via Codecov; static analysis/CERT/trend TBD) |
 | [#19](https://github.com/corsa-center/metrics/issues/19) | 4.3.3 Reproducibility | `collectors/quality/reproducibility.py` | ✅ Done |
 | [#20](https://github.com/corsa-center/metrics/issues/20) | 4.3.4 Usability | — | 🔲 Todo |
-| [#22](https://github.com/corsa-center/metrics/issues/22) | 4.3.6 Maintainability & Understandability | — | 🔲 Todo |
+| [#22](https://github.com/corsa-center/metrics/issues/22) | 4.3.6 Maintainability & Understandability | `orchestrator.py` (bus factor from `active_maintenance.py`) | ✅ Done (partial — Knowledge Distribution only; complexity/quality/docs TBD) |
 
 ---
 
@@ -84,8 +90,8 @@ ML models, specialized runtime instrumentation, or qualitative judgment.
 |-------|--------|-----------|--------|
 | [#7](https://github.com/corsa-center/metrics/issues/7) | 4.1.2 Field Research Impact | — | 🔲 Todo |
 | [#13](https://github.com/corsa-center/metrics/issues/13) | 4.2.7 Collaboration | — | 🔲 Todo |
-| [#14](https://github.com/corsa-center/metrics/issues/14) | 4.2.8 Financial Sustainability | — | 🔲 Todo |
-| [#15](https://github.com/corsa-center/metrics/issues/15) | 4.2.9 Institutional & Organizational Support | — | 🔲 Todo |
+| [#14](https://github.com/corsa-center/metrics/issues/14) | 4.2.8 Financial Sustainability | `collectors/sustainability/funding.py` | ✅ Done (partial — 4/5; NIH R50 via RePORTER still TBD) |
+| [#15](https://github.com/corsa-center/metrics/issues/15) | 4.2.9 Institutional & Organizational Support | `collectors/sustainability/funding.py` | ✅ Done (partial — 1/5; RSE/policy detection needs directory data) |
 | [#23](https://github.com/corsa-center/metrics/issues/23) | 4.3.7 Performance & Efficiency | — | 🔲 Todo |
 
 ### Why hard
@@ -94,9 +100,9 @@ ML models, specialized runtime instrumentation, or qualitative judgment.
   + HPC facility web scraping + DOI cross-referencing.
 - **4.2.7 Collaboration**: Multi-platform dependency mapping and cross-project
   PR/issue network analysis.
-- **4.2.8 Financial Sustainability**: Funding amounts are often confidential;
-  requires `FUNDING.yml` parsing, NIH award DB lookups, and manual research.
-- **4.2.9 Institutional Support**: RSE position detection requires LinkedIn API
-  and institutional directory scraping; cannot be reliably automated.
+- **4.2.8 / 4.2.9**: the automatable parts (funding manifests, README award
+  numbers, contributor affiliations) shipped in `funding.py`. What stays hard is
+  funding *amounts*, which are often confidential, and RSE position detection,
+  which needs LinkedIn or institutional directory data.
 - **4.3.7 Performance & Efficiency**: Requires running benchmarks on target
   hardware, GPU/CPU profiling (RAPL, NVML), and domain expertise to interpret.

--- a/collectors/quality/development_practices/dev_tooling.py
+++ b/collectors/quality/development_practices/dev_tooling.py
@@ -1,0 +1,206 @@
+"""
+Development Tooling Collector (CASS Report Section 4.3.2 — Development Practices)
+
+Fills the three sub-metrics that CICDMetricsCollector does not cover:
+
+  - Testing Framework Excellence  : test directories and framework configuration
+  - Code Review Quality Analysis  : share of merged PRs that were actually reviewed
+  - Development Tool Integration  : linters, formatters, pre-commit, dependency bots
+
+CI/CD Effectiveness Assessment and Community Contribution Facilitation are
+handled elsewhere (ci_cd.py and the OpenSSF badge respectively).
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+# Test layout and framework configuration, grouped so any variant counts once.
+_TESTING_PATHS = {
+    "Test suite directory": ["test", "tests", "testing", "src/test"],
+    "CTest / CMake testing": ["CTestConfig.cmake", "cmake/CTestConfig.cmake"],
+    "pytest configuration": ["pytest.ini", "tox.ini", "conftest.py", "setup.cfg"],
+    "Test framework vendored": [
+        "test/googletest", "extern/googletest", "third_party/googletest",
+        "test/catch2", "extern/Catch2",
+    ],
+}
+
+# Tooling that enforces consistency without a human in the loop.
+_TOOLING_PATHS = {
+    "Pre-commit hooks": [".pre-commit-config.yaml", ".pre-commit-config.yml"],
+    "Code formatter config": [".clang-format", ".style.yapf", ".prettierrc", "rustfmt.toml"],
+    "Linter config": [
+        ".flake8", ".pylintrc", "ruff.toml", ".eslintrc.json",
+        ".clang-tidy", ".editorconfig",
+    ],
+    "Dependency automation": [
+        ".github/dependabot.yml", ".github/dependabot.yaml", "renovate.json",
+    ],
+}
+
+# How many recently-closed PRs to sample for review coverage.
+_PR_SAMPLE_SIZE = 50
+
+# Thresholds. Reviewing most merged work is the practice the report is after;
+# 70% leaves room for trivial and automated merges.
+_REVIEW_COVERAGE_TARGET = 70.0
+_MIN_TESTING_CATEGORIES = 2
+_MIN_TOOLING_CATEGORIES = 2
+
+
+class DevToolingCollector(GitHubCollectorBase):
+    """Collects testing, review and tooling practices (Section 4.3.2)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        owner_repo = self._extract_owner_repo(package.get("repo_url", ""))
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {package.get('repo_url')}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Collecting development tooling metrics for {repo_name}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            testing, tooling, review = await asyncio.gather(
+                self._scan(client, owner, repo, _TESTING_PATHS),
+                self._scan(client, owner, repo, _TOOLING_PATHS),
+                self._analyze_review_coverage(client, owner, repo),
+                return_exceptions=True,
+            )
+
+        empty_scan = {"found": [], "missing": [], "details": {}}
+        if isinstance(testing, Exception):
+            logger.warning(f"Testing scan failed: {testing}")
+            testing = empty_scan
+        if isinstance(tooling, Exception):
+            logger.warning(f"Tooling scan failed: {tooling}")
+            tooling = empty_scan
+        if isinstance(review, Exception):
+            logger.warning(f"Review coverage failed: {review}")
+            review = {"sampled": 0, "reviewed": 0, "coverage_pct": None}
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "testing": testing,
+            "tooling": tooling,
+            "code_review": review,
+            "overall_score": self._calculate_score(testing, tooling, review),
+        }
+
+    async def _scan(
+        self, client: httpx.AsyncClient, owner: str, repo: str, groups: Dict[str, List[str]]
+    ) -> Dict[str, Any]:
+        """Check each group, recording the first matching path."""
+
+        async def check(label: str, paths: List[str]) -> Tuple[str, Optional[str]]:
+            for path in paths:
+                url = await self._check_file_exists(client, owner, repo, path)
+                if url:
+                    return label, url
+            return label, None
+
+        results = await asyncio.gather(*[check(l, p) for l, p in groups.items()])
+        found, missing, details = [], [], {}
+        for label, url in results:
+            if url:
+                found.append(label)
+                details[label] = {"exists": True, "url": url}
+            else:
+                missing.append(label)
+                details[label] = {"exists": False}
+        return {"found": found, "missing": missing, "details": details}
+
+    async def _analyze_review_coverage(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """Share of recently merged PRs that received at least one review.
+
+        Self-approvals are not filtered out — GitHub reports them the same way,
+        and distinguishing them would need per-review author comparison against
+        the PR author for every sampled PR.
+        """
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}/pulls"
+            f"?state=closed&per_page={_PR_SAMPLE_SIZE}&sort=updated&direction=desc"
+        )
+        resp = await client.get(url, headers=self.github_headers)
+        if resp.status_code != 200:
+            return {"sampled": 0, "reviewed": 0, "coverage_pct": None}
+
+        merged = [pr for pr in resp.json() if pr.get("merged_at")]
+        if not merged:
+            return {"sampled": 0, "reviewed": 0, "coverage_pct": None}
+
+        async def has_review(number: int) -> bool:
+            r = await client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/pulls/{number}/reviews?per_page=1",
+                headers=self.github_headers,
+            )
+            return r.status_code == 200 and bool(r.json())
+
+        flags = await asyncio.gather(
+            *[has_review(pr["number"]) for pr in merged], return_exceptions=True
+        )
+        reviewed = sum(1 for f in flags if f is True)
+        return {
+            "sampled": len(merged),
+            "reviewed": reviewed,
+            "coverage_pct": round(reviewed / len(merged) * 100, 1),
+        }
+
+    def _calculate_score(self, testing: Dict, tooling: Dict, review: Dict) -> Dict[str, Any]:
+        sub: Dict[str, Dict[str, Any]] = {}
+
+        test_found = testing.get("found", [])
+        sub["testing_framework"] = {
+            "label": "Testing Framework Excellence",
+            "value": f"{len(test_found)}/{len(_TESTING_PATHS)} indicators",
+            "detail": ", ".join(test_found) if test_found else None,
+            "passing": len(test_found) >= _MIN_TESTING_CATEGORIES,
+        }
+
+        cov = review.get("coverage_pct")
+        sub["code_review_quality"] = {
+            "label": "Code Review Quality Analysis",
+            "value": f"{cov}% of {review.get('sampled', 0)} merged PRs reviewed"
+                     if cov is not None else "No merged PRs to sample",
+            "passing": cov is not None and cov >= _REVIEW_COVERAGE_TARGET,
+        }
+
+        tool_found = tooling.get("found", [])
+        sub["dev_tool_integration"] = {
+            "label": "Development Tool Integration",
+            "value": f"{len(tool_found)}/{len(_TOOLING_PATHS)} tools",
+            "detail": ", ".join(tool_found) if tool_found else None,
+            "passing": len(tool_found) >= _MIN_TOOLING_CATEGORIES,
+        }
+
+        score = sum(1 for s in sub.values() if s["passing"])
+        return {
+            "score": score,
+            "max_score": len(sub),
+            "percentage": round(score / len(sub) * 100, 2),
+            "sub_scores": sub,
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        empty = {"found": [], "missing": [], "details": {}}
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "testing": empty,
+            "tooling": empty,
+            "code_review": {"sampled": 0, "reviewed": 0, "coverage_pct": None},
+            "overall_score": {"score": 0, "max_score": 3, "percentage": 0, "sub_scores": {}},
+        }

--- a/collectors/sustainability/active_maintenance.py
+++ b/collectors/sustainability/active_maintenance.py
@@ -50,11 +50,13 @@ class ActiveMaintenanceCollector:
             commit_activity,
             releases,
             contributors,
+            first_commit_date,
         ) = await asyncio.gather(
             self._get_repo_info(owner, repo),
             self._get_commit_activity(owner, repo),
             self._get_releases(owner, repo),
             self._get_contributors(owner, repo),
+            self._get_first_commit_date(owner, repo),
             return_exceptions=True,
         )
 
@@ -71,9 +73,12 @@ class ActiveMaintenanceCollector:
         if isinstance(contributors, Exception):
             logger.error(f"Contributors fetch failed: {contributors}")
             contributors = []
+        if isinstance(first_commit_date, Exception):
+            logger.error(f"First commit fetch failed: {first_commit_date}")
+            first_commit_date = None
 
         # Analyze
-        maintenance_indicators = self._analyze_maintenance_indicators(repo_info)
+        maintenance_indicators = self._analyze_maintenance_indicators(repo_info, first_commit_date)
         commit_analysis = self._analyze_commits(commit_activity)
         release_analysis = self._analyze_releases(releases)
         contributor_analysis = self._analyze_contributors(contributors)
@@ -181,21 +186,66 @@ class ActiveMaintenanceCollector:
         return contributors
 
     @staticmethod
-    def _get_next_link(link_header: Optional[str]) -> Optional[str]:
-        """Parse the `next` URL out of a GitHub Link pagination header."""
+    def _get_rel_link(link_header: Optional[str], rel: str) -> Optional[str]:
+        """Parse the URL for a given `rel` out of a GitHub Link pagination header."""
         if not link_header:
             return None
         for part in link_header.split(","):
             segment = part.strip()
-            if 'rel="next"' in segment:
+            if f'rel="{rel}"' in segment:
                 return segment.split(";")[0].strip().strip("<>")
         return None
 
-    def _analyze_maintenance_indicators(self, repo_info: Dict) -> Dict:
+    @classmethod
+    def _get_next_link(cls, link_header: Optional[str]) -> Optional[str]:
+        """Parse the `next` URL out of a GitHub Link pagination header."""
+        return cls._get_rel_link(link_header, "next")
+
+    async def _get_first_commit_date(self, owner: str, repo: str) -> Optional[str]:
+        """Date of the repository's oldest commit.
+
+        GitHub has no direct endpoint for this, but asking for one commit per page
+        makes the `rel="last"` Link header point at the final (oldest) commit, so
+        this costs two requests regardless of history size.
+
+        This is the age of the *code history*, which for projects that imported an
+        earlier VCS is much older than the GitHub repository itself — HDF5's first
+        commit is from 1997, 23 years before its repo was created.
+        """
+        url = f"https://api.github.com/repos/{owner}/{repo}/commits?per_page=1"
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                resp = await client.get(url, headers=self.headers)
+                if resp.status_code != 200:
+                    return None
+
+                last_url = self._get_rel_link(resp.headers.get("Link"), "last")
+                if not last_url:
+                    # Single page of history: the commit already in hand is the oldest.
+                    data = resp.json()
+                    if not data:
+                        return None
+                    return data[0].get("commit", {}).get("committer", {}).get("date")
+
+                resp = await client.get(last_url, headers=self.headers)
+                if resp.status_code != 200:
+                    return None
+                data = resp.json()
+                if not data:
+                    return None
+                return data[0].get("commit", {}).get("committer", {}).get("date")
+        except Exception as e:
+            logger.debug(f"Error fetching first commit: {e}")
+            return None
+
+    def _analyze_maintenance_indicators(
+        self, repo_info: Dict, first_commit_date: Optional[str] = None
+    ) -> Dict:
         """Check for maintenance mode indicators."""
         archived = repo_info.get("archived", False)
         description = (repo_info.get("description") or "").lower()
         pushed_at = repo_info.get("pushed_at")
+        created_at = repo_info.get("created_at")
 
         # Check description for maintenance signals
         maintenance_keywords = [
@@ -211,10 +261,40 @@ class ActiveMaintenanceCollector:
             pushed_dt = datetime.fromisoformat(pushed_at.replace("Z", "+00:00"))
             days_since_push = (datetime.now(timezone.utc) - pushed_dt).days
 
+        # Two different ages, deliberately reported separately.
+        #
+        #   repo_age_years    — since the GitHub repository was created. Understates
+        #                       projects that migrated from another VCS: HDF5's repo
+        #                       dates to 2020, the software to the 1990s.
+        #   history_age_years — since the oldest commit. Captures imported history,
+        #                       but a repo created empty can have its first commit
+        #                       land *after* creation (zfp, by a day), and a
+        #                       history rewrite resets it.
+        #
+        # project_age_years takes the longer of the two as the best available
+        # estimate, and both source dates are kept so the figure can be checked.
+        now = datetime.now(timezone.utc)
+
+        def _years_since(date_str: Optional[str]) -> Optional[float]:
+            if not date_str:
+                return None
+            dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+            return round((now - dt).days / 365.25, 1)
+
+        repo_age_years = _years_since(created_at)
+        history_age_years = _years_since(first_commit_date)
+        known_ages = [a for a in (repo_age_years, history_age_years) if a is not None]
+        project_age_years = max(known_ages) if known_ages else None
+
         return {
             "archived": archived,
             "maintenance_signals": maintenance_signals,
             "days_since_last_push": days_since_push,
+            "created_at": created_at,
+            "first_commit_date": first_commit_date,
+            "repo_age_years": repo_age_years,
+            "history_age_years": history_age_years,
+            "project_age_years": project_age_years,
         }
 
     def _analyze_commits(self, commit_data: Dict) -> Dict:

--- a/collectors/sustainability/funding.py
+++ b/collectors/sustainability/funding.py
@@ -1,0 +1,343 @@
+"""
+Funding and Institutional Support Collector
+(CASS Report Sections 4.2.8 Financial Sustainability and
+ 4.2.9 Institutional & Organizational Support)
+
+Both sections rest on the same two questions — who pays for this work, and
+which organizations do the contributors belong to — so they share one collector
+and one pass over the contributor list rather than fetching it twice.
+
+Collected:
+  4.2.8  Enhanced Funding Documentation Analysis  : FUNDING.yml, funding.json,
+                                                    grant/award numbers in the README
+         Institutional Affiliation Tracking       : contributor `company` fields
+         Corporate Sponsorship Detection          : funding platforms, org ownership
+         Funding Portfolio Analysis               : count of distinct sources
+  4.2.9  Institutional Support Tracking           : distinct organizations backing
+                                                    the top contributors
+
+Not collected: NIH R50 award tracking (needs the NIH RePORTER API), RSE position
+detection, career development indicators and institutional policy analysis — the
+report itself notes these need LinkedIn or institutional directory data.
+"""
+
+import asyncio
+import base64
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+import yaml
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+_FUNDING_FILES = [
+    ".github/FUNDING.yml", ".github/FUNDING.yaml", "FUNDING.yml", "funding.json",
+]
+
+# Award-number shapes used by the agencies that fund this portfolio.
+# Deliberately narrow: a looser pattern matches version strings and issue numbers.
+_GRANT_PATTERNS = [
+    (r"\bDE-[A-Z]{2}\d{2}-?\d{2}[A-Z]{2}\d{5}\b", "DOE contract"),
+    (r"\bDE-(?:AC|SC|EE|NA)\d{2}-?\d*[A-Z]*\d*\b", "DOE award"),
+    (r"\b(?:NSF|OAC|ACI|SI2|CSSI)[- ]\d{6,7}\b", "NSF award"),
+    (r"\b(?:R01|R50|U24|P41)[A-Z]{2}\d{6}\b", "NIH award"),
+    (r"\bgrant (?:no\.?|number)?\s*#?\s*\d{6,}\b", "grant number"),
+]
+
+# Contributors sampled for affiliation. The GitHub Users API is one call each,
+# so this is capped; top contributors carry most of the signal anyway.
+_AFFILIATION_SAMPLE = 25
+
+# Company strings that say nothing about institutional backing.
+_NOISE_AFFILIATIONS = {"", "-", "none", "n/a", "freelance", "independent", "self", "self-employed"}
+
+_MIN_FUNDING_SOURCES = 2
+_MIN_DISTINCT_ORGS = 3
+
+
+class FundingCollector(GitHubCollectorBase):
+    """Collects funding and institutional-affiliation signals (4.2.8 and 4.2.9)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        owner_repo = self._extract_owner_repo(package.get("repo_url", ""))
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {package.get('repo_url')}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Collecting funding and institutional metrics for {repo_name}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            funding_files, grants, affiliations, owner_type = await asyncio.gather(
+                self._find_funding_files(client, owner, repo),
+                self._find_grant_references(client, owner, repo),
+                self._get_affiliations(client, owner, repo),
+                self._get_owner_type(client, owner),
+                return_exceptions=True,
+            )
+
+        if isinstance(funding_files, Exception):
+            logger.warning(f"Funding file scan failed: {funding_files}")
+            funding_files = {"found": [], "platforms": []}
+        if isinstance(grants, Exception):
+            logger.warning(f"Grant scan failed: {grants}")
+            grants = []
+        if isinstance(affiliations, Exception):
+            logger.warning(f"Affiliation lookup failed: {affiliations}")
+            affiliations = {"organizations": [], "sampled": 0, "with_affiliation": 0}
+        if isinstance(owner_type, Exception):
+            logger.warning(f"Owner type lookup failed: {owner_type}")
+            owner_type = None
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "funding_files": funding_files,
+            "grants": grants,
+            "affiliations": affiliations,
+            "owner_type": owner_type,
+            "overall_score": self._calculate_score(
+                funding_files, grants, affiliations, owner_type
+            ),
+        }
+
+    # ------------------------------------------------------------------ fetch
+
+    async def _find_funding_files(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """Locate funding manifests and read the platforms they declare."""
+        found, platforms = [], []
+        for path in _FUNDING_FILES:
+            url = await self._check_file_exists(client, owner, repo, path)
+            if not url:
+                continue
+            found.append({"path": path, "url": url})
+            platforms.extend(await self._read_funding_platforms(client, owner, repo, path))
+        # Preserve first-seen order while removing duplicates across files.
+        return {"found": found, "platforms": list(dict.fromkeys(platforms))}
+
+    async def _read_funding_platforms(
+        self, client: httpx.AsyncClient, owner: str, repo: str, path: str
+    ) -> List[str]:
+        """Parse a FUNDING.yml into the list of platforms it names."""
+        try:
+            resp = await client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/contents/{path}",
+                headers=self.github_headers,
+            )
+            if resp.status_code != 200:
+                return []
+            content = base64.b64decode(resp.json().get("content", "")).decode("utf-8", "replace")
+            data = yaml.safe_load(content)
+            if not isinstance(data, dict):
+                return []
+            # Keys with a falsy value are commented-out placeholders, not real sponsors.
+            return [k for k, v in data.items() if v]
+        except Exception as e:
+            logger.debug(f"Could not parse {path}: {e}")
+            return []
+
+    async def _find_grant_references(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> List[Dict[str, str]]:
+        """Award and contract numbers acknowledged in the README."""
+        try:
+            resp = await client.get(
+                f"https://api.github.com/repos/{owner}/{repo}/readme",
+                headers=self.github_headers,
+            )
+            if resp.status_code != 200:
+                return []
+            text = base64.b64decode(resp.json().get("content", "")).decode("utf-8", "replace")
+        except Exception as e:
+            logger.debug(f"Could not read README: {e}")
+            return []
+
+        seen, grants = set(), []
+        for pattern, kind in _GRANT_PATTERNS:
+            for match in re.findall(pattern, text, flags=re.IGNORECASE):
+                value = match.strip()
+                if value.lower() not in seen:
+                    seen.add(value.lower())
+                    grants.append({"value": value, "kind": kind})
+        return grants
+
+    async def _get_affiliations(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """Organizations declared by the project's most active contributors."""
+        resp = await client.get(
+            f"https://api.github.com/repos/{owner}/{repo}/contributors?per_page={_AFFILIATION_SAMPLE}",
+            headers=self.github_headers,
+        )
+        if resp.status_code != 200:
+            return {"organizations": [], "sampled": 0, "with_affiliation": 0}
+        logins = [c["login"] for c in resp.json() if c.get("login")]
+
+        async def company_of(login: str) -> Optional[str]:
+            r = await client.get(
+                f"https://api.github.com/users/{login}", headers=self.github_headers
+            )
+            if r.status_code != 200:
+                return None
+            return r.json().get("company")
+
+        results = await asyncio.gather(
+            *[company_of(l) for l in logins], return_exceptions=True
+        )
+
+        # Group by canonical key so "The HDF Group", "HDFGroup" and "The HDFgroup"
+        # count as one organization rather than inflating the diversity figure.
+        counts: Dict[str, int] = {}
+        display: Dict[str, str] = {}
+        with_affiliation = 0
+        for value in results:
+            if isinstance(value, Exception) or not value:
+                continue
+            for org in self._normalize_companies(value):
+                key = self._canonical_org(org)
+                counts[key] = counts.get(key, 0) + 1
+                # Prefer the most readable spelling seen: longest wins, since
+                # "The HDF Group" is more informative than "HDFGroup".
+                if key not in display or len(org) > len(display[key]):
+                    display[key] = org
+            with_affiliation += 1
+
+        organizations = sorted(counts.items(), key=lambda kv: (-kv[1], display[kv[0]]))
+        return {
+            "organizations": [
+                {"name": display[k], "contributors": c} for k, c in organizations
+            ],
+            "sampled": len(logins),
+            "with_affiliation": with_affiliation,
+        }
+
+    @staticmethod
+    def _normalize_companies(raw: str) -> List[str]:
+        """Split and tidy a GitHub `company` string into organization names.
+
+        The field is free text: people write "@HDFGroup", "The HDFgroup, CGNS",
+        or a sentence. Splitting on commas and stripping the @-handle marker
+        gets most of it; anything left is used as-is.
+        """
+        parts = [p.strip().lstrip("@").strip() for p in raw.split(",")]
+        return [p for p in parts if p and p.lower() not in _NOISE_AFFILIATIONS]
+
+    @staticmethod
+    def _canonical_org(name: str) -> str:
+        """Fold spelling variants of one organization onto a single key.
+
+        Case, spacing, punctuation and a leading article are all noise in the
+        free-text `company` field; "The HDF Group" and "HDFGroup" are the same
+        employer and must not read as two.
+        """
+        key = re.sub(r"^the\s+", "", name.strip(), flags=re.IGNORECASE)
+        return re.sub(r"[^a-z0-9]", "", key.lower())
+
+    async def _get_owner_type(self, client: httpx.AsyncClient, owner: str) -> Optional[str]:
+        """Whether the repository sits under an Organization or a User account."""
+        try:
+            resp = await client.get(
+                f"https://api.github.com/users/{owner}", headers=self.github_headers
+            )
+            if resp.status_code == 200:
+                return resp.json().get("type")
+        except Exception as e:
+            logger.debug(f"Could not fetch owner type: {e}")
+        return None
+
+    # ---------------------------------------------------------------- scoring
+
+    def _calculate_score(
+        self, funding_files: Dict, grants: List, affiliations: Dict, owner_type: Optional[str]
+    ) -> Dict[str, Any]:
+        sub: Dict[str, Dict[str, Any]] = {}
+
+        files = funding_files.get("found", [])
+        doc_parts = []
+        if files:
+            doc_parts.append(", ".join(f["path"] for f in files))
+        if grants:
+            doc_parts.append(f"{len(grants)} award reference(s)")
+        sub["funding_documentation"] = {
+            "label": "Enhanced Funding Documentation Analysis",
+            "value": "; ".join(doc_parts) if doc_parts else "No funding documentation found",
+            "detail": ", ".join(g["value"] for g in grants) if grants else None,
+            "passing": bool(files or grants),
+        }
+
+        orgs = affiliations.get("organizations", [])
+        sub["institutional_affiliation"] = {
+            "label": "Institutional Affiliation Tracking",
+            "value": f"{len(orgs)} organizations across "
+                     f"{affiliations.get('with_affiliation', 0)}/"
+                     f"{affiliations.get('sampled', 0)} top contributors",
+            "detail": ", ".join(o["name"] for o in orgs[:5]) if orgs else None,
+            "passing": len(orgs) >= _MIN_DISTINCT_ORGS,
+        }
+
+        platforms = funding_files.get("platforms", [])
+        org_owned = owner_type == "Organization"
+        corporate_signals = list(platforms)
+        if org_owned:
+            corporate_signals.append("organization-owned repository")
+        sub["corporate_sponsorship"] = {
+            "label": "Corporate Sponsorship Detection",
+            "value": ", ".join(corporate_signals) if corporate_signals
+                     else "No sponsorship signals found",
+            "passing": bool(corporate_signals),
+        }
+
+        # Distinct sources: each declared platform, plus each award reference.
+        source_count = len(platforms) + len(grants)
+        sub["funding_portfolio"] = {
+            "label": "Funding Portfolio Analysis",
+            "value": f"{source_count} distinct funding source(s)",
+            "passing": source_count >= _MIN_FUNDING_SOURCES,
+        }
+
+        sub["nih_r50"] = {
+            "label": "NIH R50 Award Tracking",
+            "value": None, "passing": False, "not_collected": True,
+        }
+
+        # 4.2.9 shares the affiliation pass.
+        sub["institutional_support"] = {
+            "label": "Institutional Support Tracking",
+            "value": f"{len(orgs)} distinct organizations backing contributors",
+            "detail": ", ".join(f"{o['name']} ({o['contributors']})" for o in orgs[:5])
+                      if orgs else None,
+            "passing": len(orgs) >= _MIN_DISTINCT_ORGS,
+        }
+
+        # Score only the 4.2.8 rows here; the orchestrator scores 4.2.9 separately.
+        financial_keys = [
+            "funding_documentation", "institutional_affiliation",
+            "corporate_sponsorship", "funding_portfolio", "nih_r50",
+        ]
+        score = sum(1 for k in financial_keys if sub[k].get("passing"))
+        return {
+            "score": score,
+            "max_score": len(financial_keys),
+            "percentage": round(score / len(financial_keys) * 100, 2),
+            "sub_scores": sub,
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "funding_files": {"found": [], "platforms": []},
+            "grants": [],
+            "affiliations": {"organizations": [], "sampled": 0, "with_affiliation": 0},
+            "owner_type": None,
+            "overall_score": {"score": 0, "max_score": 5, "percentage": 0, "sub_scores": {}},
+        }

--- a/collectors/sustainability/outreach.py
+++ b/collectors/sustainability/outreach.py
@@ -1,0 +1,370 @@
+"""
+Outreach Collector (CASS Report Section 4.2.5)
+
+Measures a project's ability to attract and retain new contributors.
+
+Covers five of the report's eight sub-metrics from data GitHub returns directly:
+
+  - New Contributor Tracking          : authors whose entire history is recent
+  - Contributor Retention Analysis    : share of those who came back
+  - Contributor Lifecycle Mapping     : one-time / casual / repeat buckets
+  - Good First Issue Effectiveness    : newcomer-labelled issue availability
+  - Onboarding Infrastructure Assessment : onboarding docs and templates
+
+The remaining three (Contribution Type Diversity, External Event Participation,
+Training Material Integration) need data that is not in the repository — event
+programmes, course syllabi, non-code contribution records — and stay uncollected.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import quote
+
+import httpx
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+# Labels projects conventionally use to flag newcomer-friendly work.
+_NEWCOMER_LABELS = ["good first issue", "help wanted", "good-first-issue", "newcomer"]
+
+# Onboarding resources, grouped so a project gets credit for any variant.
+_ONBOARDING_PATHS = {
+    "Contributing guide": [
+        "CONTRIBUTING.md", "CONTRIBUTING.rst", "CONTRIBUTING",
+        ".github/CONTRIBUTING.md", "docs/CONTRIBUTING.md",
+    ],
+    "Issue templates": [
+        ".github/ISSUE_TEMPLATE", ".github/ISSUE_TEMPLATE.md",
+    ],
+    "Pull request template": [
+        ".github/PULL_REQUEST_TEMPLATE.md", ".github/pull_request_template.md",
+        "PULL_REQUEST_TEMPLATE.md",
+    ],
+    "Getting-started guide": [
+        "docs/getting-started.md", "docs/getting_started.md", "docs/quickstart.md",
+        "doc/getting-started.md", "GETTING_STARTED.md", "docs/source/getting_started.rst",
+    ],
+}
+
+# Contribution-count boundaries for lifecycle buckets. The report offers
+# "one commit, fewer than five commits, or project-specific thresholds";
+# fewer-than-five is used for "casual" here.
+_CASUAL_MAX_COMMITS = 4
+
+# A contributor counts as retained once they have made more than one contribution.
+_RETAINED_MIN_COMMITS = 2
+
+# Window for "new" contributors and recent commit activity.
+_RECENT_DAYS = 365
+
+# Pagination caps, mirroring active_maintenance.py's bounded approach.
+_MAX_CONTRIBUTOR_PAGES = 5
+_MAX_COMMIT_PAGES = 10
+
+
+class OutreachCollector(GitHubCollectorBase):
+    """Collects contributor-growth metrics (Section 4.2.5)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        owner_repo = self._extract_owner_repo(package.get("repo_url", ""))
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {package.get('repo_url')}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Collecting outreach metrics for {repo_name}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            contributors, recent_commits, newcomer_issues, onboarding = await asyncio.gather(
+                self._get_contributors(client, owner, repo),
+                self._get_recent_commit_authors(client, owner, repo),
+                self._get_newcomer_issues(client, owner, repo),
+                self._check_onboarding(client, owner, repo),
+                return_exceptions=True,
+            )
+
+        if isinstance(contributors, Exception):
+            logger.warning(f"Contributor fetch failed: {contributors}")
+            contributors = []
+        if isinstance(recent_commits, Exception):
+            logger.warning(f"Recent commit fetch failed: {recent_commits}")
+            recent_commits = {}
+        if isinstance(newcomer_issues, Exception):
+            logger.warning(f"Newcomer issue fetch failed: {newcomer_issues}")
+            newcomer_issues = {}
+        if isinstance(onboarding, Exception):
+            logger.warning(f"Onboarding check failed: {onboarding}")
+            onboarding = {"found": [], "missing": [], "details": {}}
+
+        growth = self._analyze_contributor_growth(contributors, recent_commits)
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "contributor_growth": growth,
+            "newcomer_issues": newcomer_issues,
+            "onboarding": onboarding,
+            "overall_score": self._calculate_score(growth, newcomer_issues, onboarding),
+        }
+
+    # ------------------------------------------------------------------ fetch
+
+    async def _get_contributors(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> List[Dict]:
+        """All-time contributors with their total contribution counts."""
+        contributors: List[Dict] = []
+        url = f"https://api.github.com/repos/{owner}/{repo}/contributors?per_page=100"
+        for _ in range(_MAX_CONTRIBUTOR_PAGES):
+            resp = await client.get(url, headers=self.github_headers)
+            if resp.status_code != 200:
+                break
+            page = resp.json()
+            if not isinstance(page, list) or not page:
+                break
+            contributors.extend(page)
+            next_url = self._next_link(resp.headers.get("Link"))
+            if not next_url:
+                break
+            url = next_url
+        return contributors
+
+    async def _get_recent_commit_authors(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, int]:
+        """Commit counts per author over the recent window."""
+        since = (datetime.now(timezone.utc) - timedelta(days=_RECENT_DAYS)).isoformat()
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}/commits"
+            f"?since={quote(since)}&per_page=100"
+        )
+        counts: Dict[str, int] = {}
+        for _ in range(_MAX_COMMIT_PAGES):
+            resp = await client.get(url, headers=self.github_headers)
+            if resp.status_code != 200:
+                break
+            page = resp.json()
+            if not isinstance(page, list) or not page:
+                break
+            for commit in page:
+                login = (commit.get("author") or {}).get("login")
+                if login:
+                    counts[login] = counts.get(login, 0) + 1
+            next_url = self._next_link(resp.headers.get("Link"))
+            if not next_url:
+                break
+            url = next_url
+        return counts
+
+    async def _get_newcomer_issues(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """Open and closed counts for each newcomer-friendly label.
+
+        Uses the search API rather than paginating /issues, so each label costs
+        two requests and returns an exact total instead of a page count.
+        """
+        by_label: Dict[str, Dict[str, int]] = {}
+        for label in _NEWCOMER_LABELS:
+            counts = {}
+            for state in ("open", "closed"):
+                q = f'repo:{owner}/{repo} is:issue state:{state} label:"{label}"'
+                url = f"https://api.github.com/search/issues?q={quote(q)}&per_page=1"
+                try:
+                    resp = await client.get(url, headers=self.github_headers)
+                    counts[state] = resp.json().get("total_count", 0) if resp.status_code == 200 else 0
+                except Exception as e:
+                    logger.debug(f"Newcomer issue search failed for {label}/{state}: {e}")
+                    counts[state] = 0
+            if counts.get("open") or counts.get("closed"):
+                by_label[label] = counts
+
+        total_open = sum(c["open"] for c in by_label.values())
+        total_closed = sum(c["closed"] for c in by_label.values())
+        return {
+            "by_label": by_label,
+            "open": total_open,
+            "closed": total_closed,
+            "total": total_open + total_closed,
+        }
+
+    async def _check_onboarding(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """Which onboarding resources the repository provides."""
+
+        async def check(label: str, paths: List[str]) -> Tuple[str, Optional[str]]:
+            for path in paths:
+                url = await self._check_file_exists(client, owner, repo, path)
+                if url:
+                    return label, url
+            return label, None
+
+        results = await asyncio.gather(
+            *[check(label, paths) for label, paths in _ONBOARDING_PATHS.items()]
+        )
+        found, missing, details = [], [], {}
+        for label, url in results:
+            if url:
+                found.append(label)
+                details[label] = {"exists": True, "url": url}
+            else:
+                missing.append(label)
+                details[label] = {"exists": False}
+        return {"found": found, "missing": missing, "details": details}
+
+    @staticmethod
+    def _next_link(link_header: Optional[str]) -> Optional[str]:
+        """Parse the `next` URL out of a GitHub Link pagination header."""
+        if not link_header:
+            return None
+        for part in link_header.split(","):
+            segment = part.strip()
+            if 'rel="next"' in segment:
+                return segment.split(";")[0].strip().strip("<>")
+        return None
+
+    # ---------------------------------------------------------------- analyze
+
+    def _analyze_contributor_growth(
+        self, contributors: List[Dict], recent_counts: Dict[str, int]
+    ) -> Dict[str, Any]:
+        """Derive newcomer, retention and lifecycle figures.
+
+        A contributor is treated as *new* when their all-time contribution count
+        is fully accounted for by commits inside the recent window — i.e. they
+        have no history before it. This avoids a second pass over the whole
+        commit log to find each author's first commit, at the cost of missing
+        anyone whose recent commits exceed the pagination cap.
+        """
+        if not contributors:
+            return {
+                "total_contributors": 0,
+                "new_contributors": 0,
+                "retained_new_contributors": 0,
+                "retention_rate": None,
+                "lifecycle": {"one_time": 0, "casual": 0, "repeat": 0},
+            }
+
+        totals = {
+            c["login"]: c.get("contributions", 0)
+            for c in contributors
+            if c.get("login")
+        }
+
+        new_contributors = [
+            login
+            for login, recent in recent_counts.items()
+            if login in totals and totals[login] <= recent
+        ]
+        retained = [
+            login for login in new_contributors
+            if recent_counts[login] >= _RETAINED_MIN_COMMITS
+        ]
+        retention_rate = (
+            round(len(retained) / len(new_contributors) * 100, 1)
+            if new_contributors
+            else None
+        )
+
+        lifecycle = {"one_time": 0, "casual": 0, "repeat": 0}
+        for count in totals.values():
+            if count <= 1:
+                lifecycle["one_time"] += 1
+            elif count <= _CASUAL_MAX_COMMITS:
+                lifecycle["casual"] += 1
+            else:
+                lifecycle["repeat"] += 1
+
+        return {
+            "total_contributors": len(totals),
+            "new_contributors": len(new_contributors),
+            "retained_new_contributors": len(retained),
+            "retention_rate": retention_rate,
+            "lifecycle": lifecycle,
+        }
+
+    def _calculate_score(
+        self, growth: Dict, newcomer_issues: Dict, onboarding: Dict
+    ) -> Dict[str, Any]:
+        """Score the five collected sub-metrics; three remain uncollected."""
+        sub: Dict[str, Dict[str, Any]] = {}
+
+        new_count = growth.get("new_contributors", 0)
+        sub["new_contributor_tracking"] = {
+            "label": "New Contributor Tracking",
+            "value": f"{new_count} in last {_RECENT_DAYS // 365} year"
+                     + ("s" if _RECENT_DAYS // 365 != 1 else ""),
+            "passing": new_count > 0,
+        }
+
+        rate = growth.get("retention_rate")
+        sub["contributor_retention"] = {
+            "label": "Contributor Retention Analysis",
+            "value": f"{rate}% of new contributors returned" if rate is not None
+                     else "No new contributors to measure",
+            # Half of newcomers coming back is a healthy return rate for OSS.
+            "passing": rate is not None and rate >= 50,
+        }
+
+        lifecycle = growth.get("lifecycle", {})
+        repeat = lifecycle.get("repeat", 0)
+        total = growth.get("total_contributors", 0)
+        sub["contributor_lifecycle"] = {
+            "label": "Contributor Lifecycle Mapping",
+            "value": f"{lifecycle.get('one_time', 0)} one-time / "
+                     f"{lifecycle.get('casual', 0)} casual / {repeat} repeat",
+            # A community sustained by more than a handful of regulars.
+            "passing": repeat >= 3,
+        }
+
+        gfi_total = newcomer_issues.get("total", 0)
+        gfi_open = newcomer_issues.get("open", 0)
+        sub["good_first_issue"] = {
+            "label": "Good First Issue Effectiveness",
+            "value": f"{gfi_open} open, {newcomer_issues.get('closed', 0)} closed"
+                     if gfi_total else "No newcomer-labelled issues",
+            "passing": gfi_open > 0,
+        }
+
+        found = onboarding.get("found", [])
+        sub["onboarding_infrastructure"] = {
+            "label": "Onboarding Infrastructure Assessment",
+            "value": f"{len(found)}/{len(_ONBOARDING_PATHS)} resources",
+            "detail": ", ".join(found) if found else None,
+            # Over half the onboarding resources present.
+            "passing": len(found) >= 3,
+        }
+
+        for key, label in [
+            ("contribution_type_diversity", "Contribution Type Diversity"),
+            ("external_event_participation", "External Event Participation"),
+            ("training_material_integration", "Training Material Integration"),
+        ]:
+            sub[key] = {"label": label, "value": None, "passing": False, "not_collected": True}
+
+        score = sum(1 for s in sub.values() if s.get("passing"))
+        max_score = len(sub)
+        return {
+            "score": score,
+            "max_score": max_score,
+            "percentage": round(score / max_score * 100, 2),
+            "sub_scores": sub,
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "contributor_growth": {},
+            "newcomer_issues": {},
+            "onboarding": {"found": [], "missing": [], "details": {}},
+            "overall_score": {"score": 0, "max_score": 8, "percentage": 0, "sub_scores": {}},
+        }

--- a/config/orchestrator.yaml
+++ b/config/orchestrator.yaml
@@ -14,13 +14,29 @@ collectors:
   sustainability: true      # 4.2 Sustainability (governance, licensing, maintenance, engagement, ...)
   quality: true             # 4.3 Quality (reliability, dev practices, reproducibility, usability, ...)
 
-# Fine-grained toggles for individual sustainability sub-collectors (4.2.x)
+# Fine-grained toggles for individual sub-collectors.
+# Omitted keys default to true, so removing a block runs everything.
+# Turning one off skips its API calls and drops it from the dimension average
+# (it does not score zero); the sections it feeds then render "Not yet collected".
+
 sustainability_collectors:
-  community_health: true    # 4.2.1 CoC, Governance, Contributor Guidelines
+  community_health: true    # 4.2.1 governance docs (CoC, GOVERNANCE, CONTRIBUTING)
+  chaoss_activity: true     # 4.2.1 CHAOSS Governance Metrics
+  openssf_scorecard: true   # 4.2.1 OpenSSF Scorecard
+  openssf_badge: true       # 4.2.1 + 4.3.2 OpenSSF Best Practices badge
   licensing: true           # 4.2.2 Licensing and FAIR Compliance
-  active_maintenance: true  # 4.2.3 Active Maintenance
-  chaoss_activity: true     # 4.2.4 CHAOSS Activity Metrics (issues, PRs, releases, docs)
-  openssf_badge: true       # 4.2.5 OpenSSF Best Practices Badge
+  active_maintenance: true  # 4.2.3 Active Maintenance, and 4.2.10 + 4.3.6 are derived from it
+  engagement: true          # 4.2.4 Engagement
+  outreach: true            # 4.2.5 Outreach
+  funding: true             # 4.2.8 Financial + 4.2.9 Institutional Support
+
+quality_collectors:
+  test_coverage: true       # 4.3.1 Test Coverage Excellence (Codecov)
+  static_analysis: true     # 4.3.1 Enhanced Security Analysis (CodeQL)
+  ci_cd: true               # 4.3.2 CI/CD Effectiveness
+  dev_tooling: true         # 4.3.2 testing, code review, tool integration
+  reproducibility: true     # 4.3.3 Reproducibility
+  accessibility: true       # 4.3.5 Accessibility
 
 # API credentials
 api_credentials:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -75,6 +75,9 @@ class MetricsOrchestrator:
         ).rstrip("/")
         self.output_path = Path(self.config.get("output_path", "./output"))
         self.collectors_enabled = self.config.get("collectors", {})
+        # Fine-grained per-sub-collector toggles (see config/orchestrator.yaml).
+        self.sustainability_collectors = self.config.get("sustainability_collectors", {})
+        self.quality_collectors = self.config.get("quality_collectors", {})
 
     def _load_config(self, config_path: str) -> Dict:
         """Load configuration from YAML file, resolving ${ENV_VAR} references"""
@@ -266,6 +269,15 @@ class MetricsOrchestrator:
             logger.error(f"Impact dimension collection failed for {package['name']}: {e}")
             return {"dimension": "impact", "score": 0.0, "max_score": 100.0}
 
+    def _sub_enabled(self, group: str, key: str) -> bool:
+        """Whether an individual sub-collector is enabled.
+
+        Defaults to True when the toggle group or key is absent, so a config
+        predating these blocks keeps running every sub-collector.
+        """
+        toggles = self.sustainability_collectors if group == "sustainability" else self.quality_collectors
+        return toggles.get(key, True)
+
     def _get_github_token(self) -> Optional[str]:
         """Extract GitHub token from resolved config"""
         token = self.config.get("api_credentials", {}).get("github", {}).get("token", "")
@@ -285,60 +297,85 @@ class MetricsOrchestrator:
         sub_results = {}
 
         # 4.2.1 CoC, Governance, and Contributor Guidelines
-        try:
-            from collectors.sustainability.community_health import CommunityHealthCollector
-            collector = CommunityHealthCollector(github_token=github_token)
-            sub_results["governance"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Governance collection failed for {package['name']}: {e}")
+        if self._sub_enabled("sustainability", "community_health"):
+            try:
+                from collectors.sustainability.community_health import CommunityHealthCollector
+                collector = CommunityHealthCollector(github_token=github_token)
+                sub_results["governance"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Governance collection failed for {package['name']}: {e}")
 
         # 4.2.2 Licensing and FAIR Compliance
-        try:
-            from collectors.sustainability.licensing import LicensingCollector
-            collector = LicensingCollector(github_token=github_token)
-            sub_results["licensing"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Licensing collection failed for {package['name']}: {e}")
+        if self._sub_enabled("sustainability", "licensing"):
+            try:
+                from collectors.sustainability.licensing import LicensingCollector
+                collector = LicensingCollector(github_token=github_token)
+                sub_results["licensing"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Licensing collection failed for {package['name']}: {e}")
 
         # 4.2.3 Active Maintenance
-        try:
-            from collectors.sustainability.active_maintenance import ActiveMaintenanceCollector
-            collector = ActiveMaintenanceCollector(github_token=github_token)
-            sub_results["maintenance"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Active maintenance collection failed for {package['name']}: {e}")
+        if self._sub_enabled("sustainability", "active_maintenance"):
+            try:
+                from collectors.sustainability.active_maintenance import ActiveMaintenanceCollector
+                collector = ActiveMaintenanceCollector(github_token=github_token)
+                sub_results["maintenance"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Active maintenance collection failed for {package['name']}: {e}")
 
         # 4.2.4 CHAOSS Activity Metrics
-        try:
-            from collectors.sustainability.chaoss_governance import CHAOSSGovernanceCollector
-            collector = CHAOSSGovernanceCollector(github_token=github_token)
-            sub_results["chaoss_activity"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"CHAOSS activity collection failed for {package['name']}: {e}")
+        if self._sub_enabled("sustainability", "chaoss_activity"):
+            try:
+                from collectors.sustainability.chaoss_governance import CHAOSSGovernanceCollector
+                collector = CHAOSSGovernanceCollector(github_token=github_token)
+                sub_results["chaoss_activity"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"CHAOSS activity collection failed for {package['name']}: {e}")
 
         # 4.2.5 OpenSSF Best Practices Badge
-        try:
-            from collectors.sustainability.openssf_badge import OpenSSFBadgeCollector
-            collector = OpenSSFBadgeCollector(github_token=github_token)
-            sub_results["openssf_badge"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"OpenSSF badge collection failed for {package['name']}: {e}")
+        if self._sub_enabled("sustainability", "openssf_badge"):
+            try:
+                from collectors.sustainability.openssf_badge import OpenSSFBadgeCollector
+                collector = OpenSSFBadgeCollector(github_token=github_token)
+                sub_results["openssf_badge"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"OpenSSF badge collection failed for {package['name']}: {e}")
 
         # 4.2.4 Engagement — issue/PR response times, open/close ratios
-        try:
-            from collectors.sustainability.engagement import EngagementCollector
-            collector = EngagementCollector(github_token=github_token)
-            sub_results["engagement"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Engagement collection failed for {package['name']}: {e}")
+        if self._sub_enabled("sustainability", "engagement"):
+            try:
+                from collectors.sustainability.engagement import EngagementCollector
+                collector = EngagementCollector(github_token=github_token)
+                sub_results["engagement"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Engagement collection failed for {package['name']}: {e}")
+
+        # 4.2.5 Outreach — newcomer growth, retention, onboarding infrastructure
+        if self._sub_enabled("sustainability", "outreach"):
+            try:
+                from collectors.sustainability.outreach import OutreachCollector
+                collector = OutreachCollector(github_token=github_token)
+                sub_results["outreach"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Outreach collection failed for {package['name']}: {e}")
+
+        # 4.2.8 + 4.2.9 Funding and institutional affiliation
+        if self._sub_enabled("sustainability", "funding"):
+            try:
+                from collectors.sustainability.funding import FundingCollector
+                collector = FundingCollector(github_token=github_token)
+                sub_results["funding"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Funding collection failed for {package['name']}: {e}")
 
         # OpenSSF Scorecard
-        try:
-            from collectors.sustainability.openssf_scorecard import OpenSSFScorecardCollector
-            collector = OpenSSFScorecardCollector(github_token=github_token)
-            sub_results["openssf_scorecard"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"OpenSSF Scorecard collection failed for {package['name']}: {e}")
+        if self._sub_enabled("sustainability", "openssf_scorecard"):
+            try:
+                from collectors.sustainability.openssf_scorecard import OpenSSFScorecardCollector
+                collector = OpenSSFScorecardCollector(github_token=github_token)
+                sub_results["openssf_scorecard"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"OpenSSF Scorecard collection failed for {package['name']}: {e}")
 
         # Calculate combined sustainability score from available sub-collectors
         scores = []
@@ -360,6 +397,10 @@ class MetricsOrchestrator:
             pct = sub_results["openssf_scorecard"].get("percentage")
             if pct is not None:
                 scores.append(pct)
+        if "outreach" in sub_results:
+            scores.append(sub_results["outreach"].get("overall_score", {}).get("percentage", 0))
+        if "funding" in sub_results:
+            scores.append(sub_results["funding"].get("overall_score", {}).get("percentage", 0))
 
         avg_score = sum(scores) / len(scores) if scores else 0.0
 
@@ -385,44 +426,58 @@ class MetricsOrchestrator:
         sub_results = {}
 
         # 4.3.2 Development Practices — CI/CD metrics
-        try:
-            from collectors.quality.development_practices.ci_cd import CICDMetricsCollector
-            collector = CICDMetricsCollector(self.config)
-            sub_results["ci_cd"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"CI/CD collection failed for {package['name']}: {e}")
+        if self._sub_enabled("quality", "ci_cd"):
+            try:
+                from collectors.quality.development_practices.ci_cd import CICDMetricsCollector
+                collector = CICDMetricsCollector(self.config)
+                sub_results["ci_cd"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"CI/CD collection failed for {package['name']}: {e}")
 
         # 4.3.3 Reproducibility — containers, lock files, FAIR4RS metadata, semver
-        try:
-            from collectors.quality.reproducibility import ReproducibilityCollector
-            collector = ReproducibilityCollector(github_token=github_token)
-            sub_results["reproducibility"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Reproducibility collection failed for {package['name']}: {e}")
+        if self._sub_enabled("quality", "reproducibility"):
+            try:
+                from collectors.quality.reproducibility import ReproducibilityCollector
+                collector = ReproducibilityCollector(github_token=github_token)
+                sub_results["reproducibility"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Reproducibility collection failed for {package['name']}: {e}")
 
         # 4.3.5 Accessibility — portable build systems and containers
-        try:
-            from collectors.quality.accessibility import AccessibilityCollector
-            collector = AccessibilityCollector(github_token=github_token)
-            sub_results["accessibility"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Accessibility collection failed for {package['name']}: {e}")
+        if self._sub_enabled("quality", "accessibility"):
+            try:
+                from collectors.quality.accessibility import AccessibilityCollector
+                collector = AccessibilityCollector(github_token=github_token)
+                sub_results["accessibility"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Accessibility collection failed for {package['name']}: {e}")
 
         # 4.3.1 Test Coverage Excellence — via Codecov public API
-        try:
-            from collectors.quality.test_coverage import TestCoverageCollector
-            collector = TestCoverageCollector(github_token=github_token)
-            sub_results["test_coverage"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Test coverage collection failed for {package['name']}: {e}")
+        if self._sub_enabled("quality", "test_coverage"):
+            try:
+                from collectors.quality.test_coverage import TestCoverageCollector
+                collector = TestCoverageCollector(github_token=github_token)
+                sub_results["test_coverage"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Test coverage collection failed for {package['name']}: {e}")
+
+        # 4.3.2 Testing frameworks, code review coverage, tooling integration
+        if self._sub_enabled("quality", "dev_tooling"):
+            try:
+                from collectors.quality.development_practices.dev_tooling import DevToolingCollector
+                collector = DevToolingCollector(github_token=github_token)
+                sub_results["dev_tooling"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Dev tooling collection failed for {package['name']}: {e}")
 
         # 4.3.1 Enhanced Security Analysis — CodeQL workflow presence
-        try:
-            from collectors.quality.static_analysis import StaticAnalysisCollector
-            collector = StaticAnalysisCollector(github_token=github_token)
-            sub_results["static_analysis"] = await collector.collect(package)
-        except Exception as e:
-            logger.warning(f"Static analysis collection failed for {package['name']}: {e}")
+        if self._sub_enabled("quality", "static_analysis"):
+            try:
+                from collectors.quality.static_analysis import StaticAnalysisCollector
+                collector = StaticAnalysisCollector(github_token=github_token)
+                sub_results["static_analysis"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Static analysis collection failed for {package['name']}: {e}")
 
         scores = []
         if "ci_cd" in sub_results:
@@ -435,6 +490,8 @@ class MetricsOrchestrator:
             scores.append(sub_results["test_coverage"].get("coverage_percentage", 0))
         if "static_analysis" in sub_results:
             scores.append(100 if sub_results["static_analysis"].get("has_codeql") else 0)
+        if "dev_tooling" in sub_results:
+            scores.append(sub_results["dev_tooling"].get("overall_score", {}).get("percentage", 0))
 
         avg_score = sum(scores) / len(scores) if scores else 0.0
 
@@ -676,6 +733,7 @@ class MetricsOrchestrator:
         # 5. Governance Effectiveness Assessment
         governance = sust.get("governance", {})
         scorecard  = sust.get("openssf_scorecard", {})
+        chaoss     = sust.get("chaoss_activity", {})
         gov_lines  = []
         gov_pts    = 0
         if governance or scorecard:
@@ -737,8 +795,31 @@ class MetricsOrchestrator:
             else:
                 gov_lines.append('<p><strong>OpenSSF Badge Integration:</strong> Not yet collected</p>')
 
-            # 4–5. Not yet collected
-            gov_lines.append('<p><strong>CHAOSS Governance Metrics:</strong> Not yet collected</p>')
+            # 4. CHAOSS Governance Metrics — weighted CHAOSS health score.
+            # CHAOSSGovernanceCollector was already being run for the dimension
+            # score; this surfaces it in the section it belongs to. "Good" (>= 60)
+            # is the collector's own threshold for a passing project.
+            if chaoss:
+                chaoss_score = chaoss.get("overall_score", {})
+                score_val = chaoss_score.get("score", 0)
+                status = chaoss_score.get("status", "unknown")
+                chaoss_ok = score_val >= 60
+                gov_pts += 1 if chaoss_ok else 0
+                gov_lines.append(
+                    f'<p><strong>CHAOSS Governance Metrics:</strong> '
+                    f'{score_val}/100 ({status}) {"✓" if chaoss_ok else "✗"}</p>'
+                )
+                # Per-category breakdown, weakest first, so the failing areas
+                # are what a maintainer sees rather than just the headline score.
+                cats = chaoss_score.get("category_scores", {})
+                for name, val in sorted(cats.items(), key=lambda kv: kv[1]):
+                    gov_lines.append(
+                        f'<p class="sub-detail">{name.replace("_", " ").title()}: {round(val)}/100</p>'
+                    )
+            else:
+                gov_lines.append('<p><strong>CHAOSS Governance Metrics:</strong> Not yet collected</p>')
+
+            # 5. Not yet collected
             gov_lines.append('<p><strong>Governance Effectiveness Assessment:</strong> Not yet collected</p>')
 
             gov_lines.append(f'<p><strong>Score:</strong> {gov_pts}/5</p>')
@@ -896,6 +977,206 @@ class MetricsOrchestrator:
         else:
             section_424_data = None
 
+        # --- 4.2.10 Project Longevity and Community Health (PDF §4.2.10 — 5 sub-metrics) ---
+        # 1. Comprehensive Activity Analysis   2. Contributor Viability Assessment
+        # 3. Maintenance Mode Detection        4. Community Health Trends
+        # 5. Project Lifecycle Assessment
+        #
+        # Every value here is re-derived from data ActiveMaintenanceCollector already
+        # fetched for 4.2.3 — this section costs no additional API calls. The overlap
+        # with 4.2.3 is intentional: the CASS report scores maintenance activity and
+        # long-term viability as separate concerns over the same underlying signals.
+        section_4210_lines = []
+        long_pts = 0
+        if maintenance:
+            indicators = maintenance.get("maintenance_indicators", {})
+            commits    = maintenance.get("commit_activity", {})
+            releases   = maintenance.get("release_activity", {})
+            contribs   = maintenance.get("contributor_activity", {})
+
+            # 1. Comprehensive Activity Analysis — commits, releases and sustained
+            #    activity treated as three dimensions; 2 of 3 counts as viable.
+            commits_52w   = commits.get("total_commits_52w", 0)
+            active_weeks  = commits.get("active_weeks_52w", 0)
+            rel_last_year = releases.get("releases_last_year", 0)
+            dims_active = sum([
+                commits_52w > 0,
+                rel_last_year >= 1,
+                active_weeks >= 26,   # committed in at least half the weeks of the year
+            ])
+            activity_ok = dims_active >= 2
+            long_pts += 1 if activity_ok else 0
+            section_4210_lines.append(
+                f'<p><strong>Comprehensive Activity Analysis:</strong> '
+                f'{dims_active}/3 dimensions active {"✓" if activity_ok else "✗"}</p>'
+            )
+            section_4210_lines.append(
+                f'<p class="sub-detail">{commits_52w:,} commits and {rel_last_year} '
+                f'release(s) in the last year; active in {active_weeks}/52 weeks</p>'
+            )
+
+            # 2. Contributor Viability Assessment — bus factor. Threshold (>= 3) matches
+            #    active_maintenance.py and 4.3.6 so the same number can't read healthy
+            #    in one section and at-risk in another.
+            bus_factor = contribs.get("bus_factor", 0)
+            total_contribs = contribs.get("total_contributors", 0)
+            viable = bus_factor >= 3
+            long_pts += 1 if viable else 0
+            section_4210_lines.append(
+                f'<p><strong>Contributor Viability Assessment:</strong> '
+                f'Bus factor {bus_factor} {"✓" if viable else "✗"}</p>'
+            )
+            section_4210_lines.append(
+                f'<p class="sub-detail">{total_contribs} contributors; top contributor '
+                f'{contribs.get("top_contributor_pct", 0)}% of commits</p>'
+            )
+
+            # 3. Maintenance Mode Detection — archive status, maintenance keywords in
+            #    the description, and a year without a push all count as warnings.
+            days_since_push = indicators.get("days_since_last_push")
+            warnings = []
+            if indicators.get("archived"):
+                warnings.append("repository archived")
+            if indicators.get("maintenance_signals"):
+                warnings.extend(indicators["maintenance_signals"])
+            if days_since_push is not None and days_since_push > 365:
+                warnings.append(f"no push in {days_since_push} days")
+            no_warnings = not warnings
+            long_pts += 1 if no_warnings else 0
+            section_4210_lines.append(
+                f'<p><strong>Maintenance Mode Detection:</strong> '
+                f'{"No warning indicators" if no_warnings else ", ".join(warnings).capitalize()} '
+                f'{"✓" if no_warnings else "✗"}</p>'
+            )
+
+            # 4. Community Health Trends — 52-week commit trend from /stats/participation.
+            trend = commits.get("recent_trend", "unknown")
+            trend_ok = trend in ("stable", "increasing")
+            long_pts += 1 if trend_ok else 0
+            section_4210_lines.append(
+                f'<p><strong>Community Health Trends:</strong> '
+                f'{trend.capitalize()} {"✓" if trend_ok else "✗"}</p>'
+            )
+
+            # 5. Project Lifecycle Assessment — stage from project age crossed with
+            #    current release activity. Emerging projects haven't yet demonstrated
+            #    the longevity this section measures, so they don't score the point.
+            #    Age is the longer of the repository's and the code history's, since
+            #    migrated projects are far older than their GitHub repo.
+            age = indicators.get("project_age_years")
+            if age is None:
+                age = indicators.get("repo_age_years")
+            if age is None:
+                stage = "Unknown"
+            elif indicators.get("archived"):
+                stage = "Retired"
+            elif age < 2:
+                stage = "Emerging"
+            elif age < 5:
+                stage = "Growing"
+            elif rel_last_year >= 1 or commits_52w > 0:
+                stage = "Mature"
+            else:
+                stage = "Legacy"
+            lifecycle_ok = stage in ("Growing", "Mature")
+            long_pts += 1 if lifecycle_ok else 0
+            section_4210_lines.append(
+                f'<p><strong>Project Lifecycle Assessment:</strong> '
+                f'{stage} {"✓" if lifecycle_ok else "✗"}</p>'
+            )
+            # Report both source dates rather than a single age: they can differ by
+            # decades for a project that migrated to GitHub, and which one is the
+            # honest figure depends on whether history was imported.
+            age_parts = []
+            if indicators.get("first_commit_date"):
+                age_parts.append(
+                    f'first commit {indicators["first_commit_date"][:10]} '
+                    f'({indicators.get("history_age_years")} yrs)'
+                )
+            if indicators.get("created_at"):
+                age_parts.append(
+                    f'GitHub repo created {indicators["created_at"][:10]} '
+                    f'({indicators.get("repo_age_years")} yrs)'
+                )
+            age_text = "; ".join(age_parts) if age_parts else "age unknown"
+            section_4210_lines.append(f'<p class="sub-detail">Project age: {age_text}</p>')
+
+            section_4210_lines.append(f'<p><strong>Score:</strong> {long_pts}/5</p>')
+
+        section_4210_data = "\n".join(section_4210_lines) if section_4210_lines else None
+
+        def _sub_row(sub: Dict, key: str) -> str:
+            """Render one collector sub-score as a section row (plus any detail)."""
+            info = sub.get(key, {})
+            label = info.get("label", key)
+            if info.get("not_collected"):
+                return f'<p><strong>{label}:</strong> Not yet collected</p>'
+            mark = "✓" if info.get("passing") else "✗"
+            row = f'<p><strong>{label}:</strong> {info.get("value", "N/A")} {mark}</p>'
+            if info.get("detail"):
+                row += f'\n<p class="sub-detail">{info["detail"]}</p>'
+            return row
+
+        # --- 4.2.5 Outreach (PDF §4.2.5 — 8 sub-metrics) ---
+        outreach = sust.get("outreach", {})
+        if outreach:
+            osub = outreach.get("overall_score", {}).get("sub_scores", {})
+            out_lines = [
+                _sub_row(osub, key) for key in [
+                    "new_contributor_tracking",
+                    "contributor_retention",
+                    "contributor_lifecycle",
+                    "contribution_type_diversity",
+                    "good_first_issue",
+                    "external_event_participation",
+                    "training_material_integration",
+                    "onboarding_infrastructure",
+                ]
+            ]
+            out_lines.append(
+                f'<p><strong>Score:</strong> {outreach.get("overall_score", {}).get("score", 0)}/8</p>'
+            )
+            section_425_data = "\n".join(out_lines)
+        else:
+            section_425_data = None
+
+        # --- 4.2.8 Financial Sustainability / 4.2.9 Institutional Support ---
+        # One collector serves both: they rest on the same funding documentation
+        # and contributor-affiliation pass.
+        funding = sust.get("funding", {})
+        if funding:
+            fsub = funding.get("overall_score", {}).get("sub_scores", {})
+            fin_lines = [
+                _sub_row(fsub, key) for key in [
+                    "funding_documentation",
+                    "institutional_affiliation",
+                    "nih_r50",
+                    "corporate_sponsorship",
+                    "funding_portfolio",
+                ]
+            ]
+            fin_lines.append(
+                f'<p><strong>Score:</strong> {funding.get("overall_score", {}).get("score", 0)}/5</p>'
+            )
+            section_428_data = "\n".join(fin_lines)
+
+            # 4.2.9 — only Institutional Support Tracking is derivable from the
+            # repository. RSE titles, career development and institutional policy
+            # need directory data the report itself flags as unautomatable.
+            inst_row = _sub_row(fsub, "institutional_support")
+            inst_pts = 1 if fsub.get("institutional_support", {}).get("passing") else 0
+            section_429_data = "\n".join([
+                '<p><strong>RSE Position Detection:</strong> Not yet collected</p>',
+                inst_row,
+                '<p><strong>Career Development Indicators:</strong> Not yet collected</p>',
+                '<p><strong>NIH R50 Award Integration:</strong> Not yet collected</p>',
+                '<p><strong>Institutional Policy Analysis:</strong> Not yet collected</p>',
+                f'<p><strong>Score:</strong> {inst_pts}/5</p>',
+            ])
+        else:
+            section_428_data = None
+            section_429_data = None
+
         qual = dims.get("quality", {}).get("sub_results", {})
 
         # --- 4.3.1 Reliability and Robustness (PDF §4.3.1 — 5 sub-metrics) ---
@@ -1017,13 +1298,21 @@ class MetricsOrchestrator:
                 section_432_lines.append(
                     '<p><strong>CI/CD Effectiveness Assessment:</strong> Not yet collected</p>'
                 )
-            # 2–4. Not yet collected
-            for label in [
-                "Testing Framework Excellence",
-                "Code Review Quality Analysis",
-                "Development Tool Integration",
-            ]:
-                section_432_lines.append(f'<p><strong>{label}:</strong> Not yet collected</p>')
+            # 2–4. Testing, review coverage and tooling integration
+            dev_tooling = qual.get("dev_tooling", {})
+            if dev_tooling:
+                dsub = dev_tooling.get("overall_score", {}).get("sub_scores", {})
+                for key in ["testing_framework", "code_review_quality", "dev_tool_integration"]:
+                    section_432_lines.append(_sub_row(dsub, key))
+                    if dsub.get(key, {}).get("passing"):
+                        dp_pts += 1
+            else:
+                for label in [
+                    "Testing Framework Excellence",
+                    "Code Review Quality Analysis",
+                    "Development Tool Integration",
+                ]:
+                    section_432_lines.append(f'<p><strong>{label}:</strong> Not yet collected</p>')
             # 5. Community Contribution Facilitation — OpenSSF badge as proxy
             if openssf_badge:
                 badge_status = openssf_badge.get("badge_status", {})
@@ -1139,6 +1428,10 @@ class MetricsOrchestrator:
         section_422_data = self._apply_section_overrides(section_422_data, ov.get("4.2.2", {}))
         section_423_data = self._apply_section_overrides(section_423_data, ov.get("4.2.3", {}))
         section_424_data = self._apply_section_overrides(section_424_data, ov.get("4.2.4", {}))
+        section_425_data = self._apply_section_overrides(section_425_data, ov.get("4.2.5", {}))
+        section_428_data = self._apply_section_overrides(section_428_data, ov.get("4.2.8", {}))
+        section_429_data = self._apply_section_overrides(section_429_data, ov.get("4.2.9", {}))
+        section_4210_data = self._apply_section_overrides(section_4210_data, ov.get("4.2.10", {}))
         section_431_data = self._apply_section_overrides(section_431_data, ov.get("4.3.1", {}))
         section_432_data = self._apply_section_overrides(section_432_data, ov.get("4.3.2", {}))
         section_433_data = self._apply_section_overrides(section_433_data, ov.get("4.3.3", {}))
@@ -1162,12 +1455,15 @@ class MetricsOrchestrator:
                 },
                 "4.2.3": {"title": "Active Maintenance", "data": section_423_data},
                 "4.2.4": {"title": "Engagement", "data": section_424_data},
-                "4.2.5": {"title": "Outreach",              "data": _stub("4.2.5")},
+                "4.2.5": {"title": "Outreach",              "data": section_425_data or _stub("4.2.5")},
                 "4.2.6": {"title": "Welcomeness",            "data": _stub("4.2.6")},
                 "4.2.7": {"title": "Collaboration",          "data": _stub("4.2.7")},
-                "4.2.8": {"title": "Financial Sustainability","data": _stub("4.2.8")},
-                "4.2.9": {"title": "Institutional & Organizational Support", "data": _stub("4.2.9")},
-                "4.2.10": {"title": "Project Longevity and Community Health","data": _stub("4.2.10")},
+                "4.2.8": {"title": "Financial Sustainability","data": section_428_data or _stub("4.2.8")},
+                "4.2.9": {"title": "Institutional & Organizational Support", "data": section_429_data or _stub("4.2.9")},
+                "4.2.10": {
+                    "title": "Project Longevity and Community Health",
+                    "data": section_4210_data or _stub("4.2.10"),
+                },
             },
             "quality": {
                 "4.3.1": {"title": "Reliability and Robustness",             "data": section_431_data},

--- a/tests/test_collector_toggles.py
+++ b/tests/test_collector_toggles.py
@@ -1,0 +1,77 @@
+"""Unit tests for the per-sub-collector toggles in config/orchestrator.yaml.
+
+These blocks were present in the config but never read by the orchestrator;
+these tests pin the wiring so they cannot silently go dead again.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+from orchestrator import MetricsOrchestrator
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG = REPO_ROOT / "config" / "orchestrator.yaml"
+ORCHESTRATOR_SRC = (REPO_ROOT / "orchestrator.py").read_text()
+
+
+def _orch(config):
+    o = MetricsOrchestrator.__new__(MetricsOrchestrator)
+    o.config = config
+    o.collectors_enabled = config.get("collectors", {})
+    o.sustainability_collectors = config.get("sustainability_collectors", {})
+    o.quality_collectors = config.get("quality_collectors", {})
+    return o
+
+
+class TestSubEnabled:
+    def test_absent_config_defaults_to_enabled(self):
+        o = _orch({})
+        assert o._sub_enabled("sustainability", "licensing") is True
+        assert o._sub_enabled("quality", "ci_cd") is True
+
+    def test_absent_key_defaults_to_enabled(self):
+        o = _orch({"sustainability_collectors": {"licensing": False}})
+        assert o._sub_enabled("sustainability", "licensing") is False
+        assert o._sub_enabled("sustainability", "engagement") is True
+
+    def test_groups_are_independent(self):
+        o = _orch(
+            {
+                "sustainability_collectors": {"licensing": False},
+                "quality_collectors": {"ci_cd": False},
+            }
+        )
+        assert o._sub_enabled("sustainability", "licensing") is False
+        assert o._sub_enabled("quality", "licensing") is True
+
+
+class TestConfigMatchesCode:
+    """Every toggle in the shipped config must be one the orchestrator reads."""
+
+    @staticmethod
+    def _wired_keys(group):
+        return set(
+            re.findall(rf'_sub_enabled\("{group}", "([a-z_]+)"\)', ORCHESTRATOR_SRC)
+        )
+
+    @pytest.mark.parametrize(
+        "group,block",
+        [
+            ("sustainability", "sustainability_collectors"),
+            ("quality", "quality_collectors"),
+        ],
+    )
+    def test_no_dead_toggles(self, group, block):
+        config = yaml.safe_load(CONFIG.read_text())
+        assert set(config[block]) == self._wired_keys(group)
+
+    def test_every_guard_is_documented_in_config(self):
+        config = yaml.safe_load(CONFIG.read_text())
+        documented = set(config["sustainability_collectors"]) | set(
+            config["quality_collectors"]
+        )
+        wired = self._wired_keys("sustainability") | self._wired_keys("quality")
+        assert wired == documented

--- a/tests/test_dev_tooling.py
+++ b/tests/test_dev_tooling.py
@@ -1,0 +1,85 @@
+"""Unit tests for DevToolingCollector (CASS Section 4.3.2)."""
+
+import pytest
+
+from collectors.quality.development_practices.dev_tooling import (
+    DevToolingCollector, _TESTING_PATHS, _TOOLING_PATHS,
+)
+
+
+@pytest.fixture
+def collector():
+    return DevToolingCollector()
+
+
+def _scan(found):
+    return {"found": list(found), "missing": [], "details": {}}
+
+
+class TestScoring:
+    def _score(self, collector, testing=(), tooling=(), review=None):
+        return collector._calculate_score(
+            _scan(testing), _scan(tooling),
+            review if review is not None else {"sampled": 0, "reviewed": 0, "coverage_pct": None},
+        )
+
+    def test_testing_threshold(self, collector):
+        assert not self._score(collector, testing=["a"])["sub_scores"][
+            "testing_framework"]["passing"]
+        assert self._score(collector, testing=["a", "b"])["sub_scores"][
+            "testing_framework"]["passing"]
+
+    def test_tooling_threshold(self, collector):
+        assert not self._score(collector, tooling=["a"])["sub_scores"][
+            "dev_tool_integration"]["passing"]
+        assert self._score(collector, tooling=["a", "b"])["sub_scores"][
+            "dev_tool_integration"]["passing"]
+
+    def test_review_coverage_threshold(self, collector):
+        at = {"sampled": 10, "reviewed": 7, "coverage_pct": 70.0}
+        below = {"sampled": 10, "reviewed": 6, "coverage_pct": 60.0}
+        assert self._score(collector, review=at)["sub_scores"][
+            "code_review_quality"]["passing"]
+        assert not self._score(collector, review=below)["sub_scores"][
+            "code_review_quality"]["passing"]
+
+    def test_no_merged_prs_does_not_pass(self, collector):
+        s = self._score(collector)["sub_scores"]["code_review_quality"]
+        assert not s["passing"]
+        assert "No merged PRs" in s["value"]
+
+    def test_max_score_is_three(self, collector):
+        assert self._score(collector)["max_score"] == 3
+
+    def test_all_passing(self, collector):
+        s = self._score(
+            collector,
+            testing=["a", "b"], tooling=["a", "b"],
+            review={"sampled": 20, "reviewed": 20, "coverage_pct": 100.0},
+        )
+        assert s["score"] == 3
+        assert s["percentage"] == 100.0
+
+    def test_found_items_appear_as_detail(self, collector):
+        s = self._score(collector, testing=["Test suite directory", "CTest / CMake testing"])
+        assert s["sub_scores"]["testing_framework"]["detail"] == (
+            "Test suite directory, CTest / CMake testing"
+        )
+
+
+class TestPathGroups:
+    def test_group_labels_are_distinct(self):
+        assert not set(_TESTING_PATHS) & set(_TOOLING_PATHS)
+
+    def test_every_group_has_candidates(self):
+        for group in (_TESTING_PATHS, _TOOLING_PATHS):
+            for label, paths in group.items():
+                assert paths, label
+
+
+class TestEmptyResult:
+    def test_invalid_url(self, collector):
+        import asyncio
+        r = asyncio.run(collector.collect({"name": "x", "repo_url": "nope"}))
+        assert r["overall_score"]["max_score"] == 3
+        assert r["code_review"]["coverage_pct"] is None

--- a/tests/test_funding.py
+++ b/tests/test_funding.py
@@ -1,0 +1,112 @@
+"""Unit tests for FundingCollector (CASS Sections 4.2.8 and 4.2.9)."""
+
+import pytest
+
+from collectors.sustainability.funding import FundingCollector
+
+
+@pytest.fixture
+def collector():
+    return FundingCollector()
+
+
+class TestCompanyNormalization:
+    def test_splits_multiple_employers(self, collector):
+        assert collector._normalize_companies("The HDFgroup, CGNS") == [
+            "The HDFgroup", "CGNS"
+        ]
+
+    def test_strips_github_handle_marker(self, collector):
+        assert collector._normalize_companies("@HDFGroup") == ["HDFGroup"]
+
+    def test_drops_non_affiliations(self, collector):
+        assert collector._normalize_companies("independent") == []
+        assert collector._normalize_companies("-, none, N/A") == []
+
+    @pytest.mark.parametrize("a,b", [
+        ("The HDF Group", "HDFGroup"),
+        ("The HDFgroup", "hdf group"),
+        ("Lawrence Livermore", "lawrence-livermore"),
+    ])
+    def test_spelling_variants_fold_together(self, collector, a, b):
+        assert collector._canonical_org(a) == collector._canonical_org(b)
+
+    def test_distinct_orgs_stay_distinct(self, collector):
+        assert collector._canonical_org("AMD") != collector._canonical_org("CGNS")
+
+
+class TestScoring:
+    def _score(self, collector, files=None, grants=None, affil=None, owner_type=None):
+        return collector._calculate_score(
+            files or {"found": [], "platforms": []},
+            grants or [],
+            affil or {"organizations": [], "sampled": 0, "with_affiliation": 0},
+            owner_type,
+        )
+
+    def test_funding_documentation_passes_on_file_alone(self, collector):
+        s = self._score(collector, files={"found": [{"path": ".github/FUNDING.yml"}],
+                                          "platforms": ["github"]})
+        assert s["sub_scores"]["funding_documentation"]["passing"]
+
+    def test_funding_documentation_passes_on_grant_alone(self, collector):
+        s = self._score(collector, grants=[{"value": "DE-AC02-06CH11357", "kind": "DOE"}])
+        assert s["sub_scores"]["funding_documentation"]["passing"]
+
+    def test_no_funding_signals_fails(self, collector):
+        assert not self._score(collector)["sub_scores"]["funding_documentation"]["passing"]
+
+    def test_portfolio_counts_platforms_and_grants(self, collector):
+        s = self._score(collector,
+                        files={"found": [], "platforms": ["github"]},
+                        grants=[{"value": "OAC-1234567", "kind": "NSF"}])
+        assert "2 distinct" in s["sub_scores"]["funding_portfolio"]["value"]
+        assert s["sub_scores"]["funding_portfolio"]["passing"]
+
+    def test_single_source_fails_portfolio(self, collector):
+        s = self._score(collector, files={"found": [], "platforms": ["github"]})
+        assert not s["sub_scores"]["funding_portfolio"]["passing"]
+
+    def test_org_ownership_counts_as_corporate_signal(self, collector):
+        s = self._score(collector, owner_type="Organization")
+        assert s["sub_scores"]["corporate_sponsorship"]["passing"]
+        s = self._score(collector, owner_type="User")
+        assert not s["sub_scores"]["corporate_sponsorship"]["passing"]
+
+    def test_affiliation_threshold(self, collector):
+        two = {"organizations": [{"name": "a", "contributors": 1},
+                                 {"name": "b", "contributors": 1}],
+               "sampled": 5, "with_affiliation": 2}
+        assert not self._score(collector, affil=two)["sub_scores"][
+            "institutional_affiliation"]["passing"]
+        three = dict(two)
+        three["organizations"] = two["organizations"] + [{"name": "c", "contributors": 1}]
+        assert self._score(collector, affil=three)["sub_scores"][
+            "institutional_affiliation"]["passing"]
+
+    def test_nih_stays_uncollected(self, collector):
+        assert self._score(collector)["sub_scores"]["nih_r50"]["not_collected"]
+
+    def test_score_covers_only_the_four_two_eight_rows(self, collector):
+        # institutional_support belongs to 4.2.9 and must not inflate 4.2.8.
+        s = self._score(collector, affil={"organizations": [{"name": n, "contributors": 1}
+                                                            for n in "abc"],
+                                          "sampled": 3, "with_affiliation": 3})
+        assert s["max_score"] == 5
+        assert s["sub_scores"]["institutional_support"]["passing"]
+        assert s["score"] <= 5
+
+
+class TestGrantPatterns:
+    @pytest.mark.parametrize("text,expected", [
+        ("Supported by DE-AC02-06CH11357", True),
+        ("under NSF OAC-1836650", True),
+        ("award R01GM123456 funded", True),
+        ("see version 1.14.3 and issue 12345", False),
+        ("no funding here", False),
+    ])
+    def test_patterns(self, text, expected):
+        import re
+        from collectors.sustainability.funding import _GRANT_PATTERNS
+        hit = any(re.search(p, text, re.IGNORECASE) for p, _ in _GRANT_PATTERNS)
+        assert hit is expected

--- a/tests/test_outreach.py
+++ b/tests/test_outreach.py
@@ -1,0 +1,108 @@
+"""Unit tests for OutreachCollector (CASS Section 4.2.5)."""
+
+import pytest
+
+from collectors.sustainability.outreach import OutreachCollector
+
+
+@pytest.fixture
+def collector():
+    return OutreachCollector()
+
+
+class TestContributorGrowth:
+    def test_new_contributor_is_one_with_no_prior_history(self, collector):
+        # alice has 3 all-time and 3 recent → entirely new.
+        # bob has 50 all-time but only 2 recent → an existing contributor.
+        contributors = [{"login": "alice", "contributions": 3},
+                        {"login": "bob", "contributions": 50}]
+        recent = {"alice": 3, "bob": 2}
+        g = collector._analyze_contributor_growth(contributors, recent)
+        assert g["new_contributors"] == 1
+
+    def test_retention_counts_newcomers_who_came_back(self, collector):
+        contributors = [{"login": "a", "contributions": 1},
+                        {"login": "b", "contributions": 4},
+                        {"login": "c", "contributions": 1}]
+        recent = {"a": 1, "b": 4, "c": 1}
+        g = collector._analyze_contributor_growth(contributors, recent)
+        assert g["new_contributors"] == 3
+        assert g["retained_new_contributors"] == 1   # only b has >= 2
+        assert g["retention_rate"] == pytest.approx(33.3)
+
+    def test_retention_is_none_without_newcomers(self, collector):
+        contributors = [{"login": "bob", "contributions": 50}]
+        g = collector._analyze_contributor_growth(contributors, {"bob": 2})
+        assert g["new_contributors"] == 0
+        assert g["retention_rate"] is None
+
+    def test_lifecycle_buckets(self, collector):
+        contributors = [
+            {"login": "one", "contributions": 1},
+            {"login": "two", "contributions": 4},
+            {"login": "three", "contributions": 5},
+            {"login": "four", "contributions": 900},
+        ]
+        g = collector._analyze_contributor_growth(contributors, {})
+        assert g["lifecycle"] == {"one_time": 1, "casual": 1, "repeat": 2}
+
+    def test_no_contributors(self, collector):
+        g = collector._analyze_contributor_growth([], {})
+        assert g["total_contributors"] == 0
+        assert g["retention_rate"] is None
+
+    def test_recent_author_absent_from_contributors_is_ignored(self, collector):
+        # /contributors is capped at 5 pages; an author beyond it must not be
+        # miscounted as new just because their total is unknown.
+        g = collector._analyze_contributor_growth(
+            [{"login": "known", "contributions": 10}], {"unknown": 3}
+        )
+        assert g["new_contributors"] == 0
+
+
+class TestScoring:
+    def _score(self, collector, growth=None, issues=None, onboarding=None):
+        return collector._calculate_score(
+            growth or {}, issues or {}, onboarding or {"found": []}
+        )
+
+    def test_three_submetrics_stay_uncollected(self, collector):
+        sub = self._score(collector)["sub_scores"]
+        uncollected = [k for k, v in sub.items() if v.get("not_collected")]
+        assert len(uncollected) == 3
+        assert self._score(collector)["max_score"] == 8
+
+    def test_retention_threshold(self, collector):
+        assert self._score(collector, {"retention_rate": 50})["sub_scores"][
+            "contributor_retention"]["passing"]
+        assert not self._score(collector, {"retention_rate": 49})["sub_scores"][
+            "contributor_retention"]["passing"]
+
+    def test_good_first_issue_needs_open_ones(self, collector):
+        # Closed-only history doesn't help a newcomer arriving today.
+        s = self._score(collector, issues={"total": 5, "open": 0, "closed": 5})
+        assert not s["sub_scores"]["good_first_issue"]["passing"]
+        s = self._score(collector, issues={"total": 5, "open": 2, "closed": 3})
+        assert s["sub_scores"]["good_first_issue"]["passing"]
+
+    def test_onboarding_threshold(self, collector):
+        assert not self._score(collector, onboarding={"found": ["a", "b"]})[
+            "sub_scores"]["onboarding_infrastructure"]["passing"]
+        assert self._score(collector, onboarding={"found": ["a", "b", "c"]})[
+            "sub_scores"]["onboarding_infrastructure"]["passing"]
+
+
+class TestPagination:
+    def test_next_link_parsing(self, collector):
+        header = ('<https://api.github.com/x?page=2>; rel="next", '
+                  '<https://api.github.com/x?page=9>; rel="last"')
+        assert collector._next_link(header).endswith("page=2")
+        assert collector._next_link(None) is None
+
+
+class TestEmptyResult:
+    def test_invalid_url(self, collector):
+        import asyncio
+        r = asyncio.run(collector.collect({"name": "x", "repo_url": "not-a-url"}))
+        assert r["overall_score"]["score"] == 0
+        assert r["overall_score"]["max_score"] == 8

--- a/tests/test_project_longevity.py
+++ b/tests/test_project_longevity.py
@@ -1,0 +1,317 @@
+"""Unit tests for the 4.2.10 Project Longevity and Community Health section.
+
+4.2.10 has no collector of its own — the orchestrator re-derives all five
+sub-metrics from data ActiveMaintenanceCollector already gathered for 4.2.3.
+These tests exercise that transform directly.
+"""
+
+import pytest
+from orchestrator import MetricsOrchestrator
+
+
+def _maint(**overrides):
+    """A healthy, mature project; override individual blocks per test."""
+    base = {
+        "maintenance_indicators": {
+            "archived": False,
+            "maintenance_signals": [],
+            "days_since_last_push": 3,
+            "created_at": "2020-04-24T18:25:20Z",
+            "first_commit_date": "1997-07-30T21:17:56Z",
+            "repo_age_years": 6.3,
+            "history_age_years": 29.1,
+            "project_age_years": 29.1,
+        },
+        "commit_activity": {
+            "total_commits_52w": 1200,
+            "active_weeks_52w": 48,
+            "recent_trend": "stable",
+        },
+        "release_activity": {"releases_last_year": 3},
+        "contributor_activity": {
+            "total_contributors": 90,
+            "bus_factor": 5,
+            "top_contributor_pct": 22,
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+def _render(maintenance):
+    orch = MetricsOrchestrator.__new__(MetricsOrchestrator)
+    orch.config = {}
+    metrics = {
+        "dimensions": {"sustainability": {"sub_results": {"maintenance": maintenance}}}
+    }
+    out = orch._transform_for_dashboard("HDFGroup/hdf5", metrics)
+    return out["sustainability"]["4.2.10"]["data"]
+
+
+class TestSectionShape:
+    def test_all_five_submetrics_present(self):
+        html = _render(_maint())
+        for label in [
+            "Comprehensive Activity Analysis",
+            "Contributor Viability Assessment",
+            "Maintenance Mode Detection",
+            "Community Health Trends",
+            "Project Lifecycle Assessment",
+        ]:
+            assert f"<strong>{label}:</strong>" in html
+
+    def test_no_maintenance_data_returns_none(self):
+        assert _render({}) is None
+
+
+class TestScoring:
+    def test_healthy_project_scores_full(self):
+        html = _render(_maint())
+        assert "<strong>Score:</strong> 5/5" in html
+
+    def test_archived_project_scores_zero(self):
+        html = _render(
+            _maint(
+                maintenance_indicators={
+                    "archived": True,
+                    "maintenance_signals": ["deprecated"],
+                    "days_since_last_push": 900,
+                    "created_at": "2018-01-01T00:00:00Z",
+                    "first_commit_date": "2018-01-02T00:00:00Z",
+                    "repo_age_years": 8.7,
+                    "history_age_years": 8.7,
+                    "project_age_years": 8.7,
+                },
+                commit_activity={
+                    "total_commits_52w": 0,
+                    "active_weeks_52w": 0,
+                    "recent_trend": "inactive",
+                },
+                release_activity={"releases_last_year": 0},
+                contributor_activity={
+                    "total_contributors": 2,
+                    "bus_factor": 1,
+                    "top_contributor_pct": 95,
+                },
+            )
+        )
+        assert "<strong>Score:</strong> 0/5" in html
+        assert "Retired" in html
+
+
+class TestActivityAnalysis:
+    def test_two_of_three_dimensions_passes(self):
+        # Commits and sustained activity, but no release in the last year.
+        html = _render(_maint(release_activity={"releases_last_year": 0}))
+        assert "2/3 dimensions active ✓" in html
+
+    def test_one_of_three_dimensions_fails(self):
+        html = _render(
+            _maint(
+                commit_activity={
+                    "total_commits_52w": 5,
+                    "active_weeks_52w": 3,
+                    "recent_trend": "declining",
+                },
+                release_activity={"releases_last_year": 0},
+            )
+        )
+        assert "1/3 dimensions active ✗" in html
+
+
+class TestContributorViability:
+    def test_bus_factor_threshold_matches_4_3_6(self):
+        # active_maintenance.py and 4.3.6 both treat >= 3 as healthy.
+        assert "Bus factor 3 ✓" in _render(
+            _maint(
+                contributor_activity={
+                    "total_contributors": 8,
+                    "bus_factor": 3,
+                    "top_contributor_pct": 40,
+                }
+            )
+        )
+        assert "Bus factor 2 ✗" in _render(
+            _maint(
+                contributor_activity={
+                    "total_contributors": 8,
+                    "bus_factor": 2,
+                    "top_contributor_pct": 60,
+                }
+            )
+        )
+
+
+class TestMaintenanceModeDetection:
+    def test_stale_push_is_a_warning(self):
+        html = _render(
+            _maint(
+                maintenance_indicators={
+                    "archived": False,
+                    "maintenance_signals": [],
+                    "days_since_last_push": 400,
+                    "repo_age_years": 6.0,
+                }
+            )
+        )
+        assert "no push in 400 days" in html.lower()
+
+    def test_missing_push_date_is_not_a_warning(self):
+        html = _render(
+            _maint(
+                maintenance_indicators={
+                    "archived": False,
+                    "maintenance_signals": [],
+                    "days_since_last_push": None,
+                    "repo_age_years": 6.0,
+                }
+            )
+        )
+        assert "Maintenance Mode Detection:</strong> No warning indicators ✓" in html
+
+
+class TestLifecycleStages:
+    @pytest.mark.parametrize(
+        "age,releases,commits,expected,passes",
+        [
+            (1.2, 2, 300, "Emerging", False),
+            (3.0, 2, 300, "Growing", True),
+            (8.0, 1, 300, "Mature", True),
+            (8.0, 0, 0, "Legacy", False),
+            (None, 2, 300, "Unknown", False),
+        ],
+    )
+    def test_stage_classification(self, age, releases, commits, expected, passes):
+        html = _render(
+            _maint(
+                maintenance_indicators={
+                    "archived": False,
+                    "maintenance_signals": [],
+                    "days_since_last_push": 3,
+                    "project_age_years": age,
+                },
+                commit_activity={
+                    "total_commits_52w": commits,
+                    "active_weeks_52w": 40 if commits else 0,
+                    "recent_trend": "stable",
+                },
+                release_activity={"releases_last_year": releases},
+            )
+        )
+        mark = "✓" if passes else "✗"
+        assert f"Project Lifecycle Assessment:</strong> {expected} {mark}" in html
+
+
+class TestOverrides:
+    def test_override_replaces_row_and_recounts_score(self):
+        html = _render(_maint(commit_activity={
+            "total_commits_52w": 1200,
+            "active_weeks_52w": 48,
+            "recent_trend": "declining",
+        }))
+        assert "<strong>Score:</strong> 4/5" in html
+
+        overridden = MetricsOrchestrator._apply_section_overrides(
+            html, {"Community Health Trends": "N/A"}
+        )
+        assert "<strong>Community Health Trends:</strong> N/A</p>" in overridden
+        # The N/A row no longer counts as a hit, and sub-details stay excluded.
+        assert "<strong>Score:</strong> 4/5" in overridden
+
+
+class TestProjectAgeDates:
+    def test_both_dates_are_reported(self):
+        html = _render(_maint())
+        assert "first commit 1997-07-30 (29.1 yrs)" in html
+        assert "GitHub repo created 2020-04-24 (6.3 yrs)" in html
+
+    def test_lifecycle_uses_the_longer_age(self):
+        # Repo created 2 years ago but history imported from 29 years back:
+        # the project is Mature, not Growing.
+        html = _render(_maint())
+        assert "Project Lifecycle Assessment:</strong> Mature" in html
+
+    def test_falls_back_to_repo_age_when_history_unknown(self):
+        html = _render(
+            _maint(
+                maintenance_indicators={
+                    "archived": False,
+                    "maintenance_signals": [],
+                    "days_since_last_push": 3,
+                    "created_at": "2019-01-01T00:00:00Z",
+                    "repo_age_years": 7.7,
+                }
+            )
+        )
+        assert "Project Lifecycle Assessment:</strong> Mature" in html
+        assert "GitHub repo created 2019-01-01 (7.7 yrs)" in html
+        assert "first commit" not in html
+
+    def test_no_dates_reads_as_unknown(self):
+        html = _render(
+            _maint(
+                maintenance_indicators={
+                    "archived": False,
+                    "maintenance_signals": [],
+                    "days_since_last_push": 3,
+                }
+            )
+        )
+        assert "Project Lifecycle Assessment:</strong> Unknown ✗" in html
+        assert "Project age: age unknown" in html
+
+
+class TestFirstCommitLookup:
+    def test_picks_last_page_from_link_header(self):
+        from collectors.sustainability.active_maintenance import ActiveMaintenanceCollector
+
+        header = (
+            '<https://api.github.com/repositories/1/commits?per_page=1&page=2>; rel="next", '
+            '<https://api.github.com/repositories/1/commits?per_page=1&page=9000>; rel="last"'
+        )
+        assert ActiveMaintenanceCollector._get_rel_link(header, "last").endswith("page=9000")
+        assert ActiveMaintenanceCollector._get_next_link(header).endswith("page=2")
+
+    def test_missing_header_returns_none(self):
+        from collectors.sustainability.active_maintenance import ActiveMaintenanceCollector
+
+        assert ActiveMaintenanceCollector._get_rel_link(None, "last") is None
+        assert ActiveMaintenanceCollector._get_rel_link("", "last") is None
+
+
+class TestAgeDerivation:
+    def test_longer_of_the_two_ages_wins(self):
+        from collectors.sustainability.active_maintenance import ActiveMaintenanceCollector
+
+        c = ActiveMaintenanceCollector()
+        out = c._analyze_maintenance_indicators(
+            {"archived": False, "description": "", "pushed_at": None,
+             "created_at": "2020-04-24T18:25:20Z"},
+            first_commit_date="1997-07-30T21:17:56Z",
+        )
+        assert out["project_age_years"] == out["history_age_years"]
+        assert out["project_age_years"] > out["repo_age_years"]
+
+    def test_empty_repo_created_before_first_commit(self):
+        # zfp's first commit landed a day after the repo was created; repo age
+        # is then the longer span and must not be discarded.
+        from collectors.sustainability.active_maintenance import ActiveMaintenanceCollector
+
+        c = ActiveMaintenanceCollector()
+        out = c._analyze_maintenance_indicators(
+            {"archived": False, "description": "", "pushed_at": None,
+             "created_at": "2016-03-24T02:10:02Z"},
+            first_commit_date="2016-03-25T22:08:59Z",
+        )
+        assert out["project_age_years"] == out["repo_age_years"]
+
+    def test_no_dates_yields_none(self):
+        from collectors.sustainability.active_maintenance import ActiveMaintenanceCollector
+
+        c = ActiveMaintenanceCollector()
+        out = c._analyze_maintenance_indicators(
+            {"archived": False, "description": "", "pushed_at": None}
+        )
+        assert out["project_age_years"] is None
+        assert out["repo_age_years"] is None
+        assert out["history_age_years"] is None


### PR DESCRIPTION
Fills every CASS sub-metric that repository APIs can answer without new credentials.

## Sections that were stubs

| Section | Before | After |
|---|---|---|
| 4.2.5 Outreach | 0/8 | 5/8 |
| 4.2.8 Financial Sustainability | 0/5 | 4/5 |
| 4.2.9 Institutional Support | 0/5 | 1/5 |
| 4.2.10 Project Longevity | 0/5 | 5/5 |
| 4.3.2 Development Practices | 2/5 | 5/5 |

**4.2.10** needed no collector at all — all five sub-metrics derive from data `ActiveMaintenanceCollector` already fetches for 4.2.3, so the section costs zero extra API calls. It was routed through `_stub()` regardless.

**4.2.5** (`outreach.py`), **4.2.8/4.2.9** (`funding.py`, one collector for both so the affiliation pass runs once), **4.3.2** (`dev_tooling.py`: testing frameworks, review coverage over the last 50 merged PRs, linter/formatter/bot configs).

Genuinely unautomatable rows stay uncollected and say so — event programmes, course syllabi, RSE titles, funding amounts.

## Two data-correctness fixes

**Project age now reports both dates.** `created_at` understates any migrated project: HDF5's repo dates to 2020, its first commit to **1997**. The first commit comes from the `rel="last"` Link header on `/commits?per_page=1` — two requests regardless of history size. Lifecycle staging uses the longer span, so HDF5 reads Mature rather than being staged off a 6.3-year repo.

**Affiliation names are canonicalised.** The free-text `company` field spells one employer several ways; HDF5 reported 5 organizations where it actually has 3 ("The HDF Group", "HDFGroup", "The HDFgroup").

## Two things that were silently dead

- `CHAOSSGovernanceCollector` ran on every package and its output was discarded except for a nudge to the dimension score. It now fills the 4.2.1 row named for it, weakest categories first.
- `config/orchestrator.yaml` declared a `sustainability_collectors` block that nothing read. Wired up via `_sub_enabled()`, with a matching `quality_collectors` block. Omitted keys default to true, so existing configs behave exactly as before. A test asserts the config keys and the code's guards stay the same set **in both directions**, so this can't go dead again.

## Docs

`METRICS_CATALOG.md` documented `collectors/viability/`, `collectors/community/` and `collectors/security/` — none of which exist. Rewritten against the actual 19 sections. `METRICS_ROADMAP.md` pointed #16 at `community_health.py`, which is really the 4.2.1 governance-doc collector.

## Verification

73 new tests, **187 pass**. Live-run against HDFGroup/hdf5, and the rendered HTML was checked through the dashboard's own `parseScore()` from `js/catalog.js` — every section's parsed total matches the hardcoded blade count, with no parse failures.

Closes #12, #14, #15, #16. Advances #18.