### PR TITLE
Fill the three Tier 0 sub-metrics from data already being fetched

### DIFF
--- a/METRICS_CATALOG.md
+++ b/METRICS_CATALOG.md
@@ -26,16 +26,16 @@ is a stub
 | 4.2.3 | Active Maintenance | 4/6 |
 | 4.2.4 | Engagement | 4/7 |
 | 4.2.5 | Outreach | 5/8 |
-| 4.2.6 | Welcomeness | ⬜ 0/7 |
+| 4.2.6 | Welcomeness | 1/7 |
 | 4.2.7 | Collaboration | ⬜ 0/5 |
 | 4.2.8 | Financial Sustainability | 4/5 |
 | 4.2.9 | Institutional & Organizational Support | 1/5 |
 | 4.2.10 | Project Longevity and Community Health | 5/5 |
 | 4.3.1 | Reliability and Robustness | 2/5 |
 | 4.3.2 | Development Practices | 5/5 |
-| 4.3.3 | Reproducibility | 4/5 |
+| 4.3.3 | Reproducibility | 5/5 |
 | 4.3.4 | Usability | ⬜ 0/5 |
-| 4.3.5 | Accessibility | 2/5 |
+| 4.3.5 | Accessibility | 3/5 |
 | 4.3.6 | Maintainability and Understandability | 1/5 |
 | 4.3.7 | Performance and Efficiency | ⬜ 0/10 |
 
@@ -148,12 +148,17 @@ literature plus facility web scraping; see the "Hard" tier in
 > recent commits exceed the 10-page pagination cap.
 
 ### 4.2.6 Welcomeness
-**Collector:** none — ⬜ stub
+**Collector:** [`welcomeness.py`](collectors/sustainability/welcomeness.py)
 
-CHAOSS Community Experience Metrics · Response Quality and Tone Analysis ·
-Communication Sentiment Analysis · Contributor Journey Mapping · Language and
-Communication Review · Leadership Role Representation · Decision-Making
-Visibility.
+| Sub-metric | Status | Source |
+|---|---|---|
+| CHAOSS Community Experience Metrics | 🔲 | — |
+| Response Quality and Tone Analysis | 🔲 | needs NL analysis of conversations |
+| Communication Sentiment Analysis | 🔲 | needs NL analysis of conversations |
+| Contributor Journey Mapping | 🔲 | — |
+| Language and Communication Review | 🔲 | needs NL analysis of documentation |
+| Leadership Role Representation | 🔲 | needs maintainer demographics |
+| Decision-Making Visibility | ✅ | `has_discussions` / `has_wiki` / `has_pages` plus roadmap, meeting notes, decision records, governance doc; passes at ≥2 signals |
 
 ### 4.2.7 Collaboration
 **Collector:** none — ⬜ stub
@@ -260,7 +265,7 @@ and rejected — its public JSON endpoint returns HTTP 403 to non-browser client
 | Containerization Excellence | ✅ | Dockerfile, Singularity/Apptainer definitions |
 | Version Control Best Practices | ✅ | semantic versioning in `/tags` |
 | Environment Management | ✅ | dependency pinning: `requirements.txt`, `poetry.lock`, `conda-lock.yml`, `package-lock.json`, `Cargo.lock`, `uv.lock` |
-| Reproducibility Documentation | 🔲 | — |
+| Reproducibility Documentation | ✅ | install/build guide, release notes, environment spec (`environment.yml`, `spack.yaml`, devcontainer) |
 
 ### 4.3.4 Usability
 **Collector:** none — ⬜ stub
@@ -270,7 +275,8 @@ Accessibility Feature Detection · Installation Success Tracking · Usage
 Analytics Integration.
 
 ### 4.3.5 Accessibility
-**Collector:** [`accessibility.py`](collectors/quality/accessibility.py)
+**Collectors:** [`accessibility.py`](collectors/quality/accessibility.py),
+[`deployment_environments.py`](collectors/quality/deployment_environments.py)
 
 | Sub-metric | Status | Source |
 |---|---|---|
@@ -278,7 +284,7 @@ Analytics Integration.
 | Container Availability Assessment | ✅ | Dockerfile, Singularity/Apptainer |
 | Architecture Compatibility Analysis | 🔲 | — |
 | Platform Documentation Evaluation | 🔲 | — |
-| Deployment Environment Testing | 🔲 | — |
+| Deployment Environment Testing | ✅ | [`deployment_environments.py`](collectors/quality/deployment_environments.py) — CI runner labels folded to OS families; passes at ≥2 |
 
 ### 4.3.6 Maintainability and Understandability
 **Collector:** none of its own — bus factor reused from
@@ -349,6 +355,7 @@ sustainability_collectors:
   active_maintenance: true  # 4.2.3, and 4.2.10 + 4.3.6 derive from it
   engagement: true          # 4.2.4
   outreach: true            # 4.2.5
+  welcomeness: true         # 4.2.6
   funding: true             # 4.2.8 + 4.2.9
 
 quality_collectors:
@@ -358,6 +365,7 @@ quality_collectors:
   dev_tooling: true         # 4.3.2
   reproducibility: true     # 4.3.3
   accessibility: true       # 4.3.5
+  deployment_environments: true  # 4.3.5
 ```
 
 Omitted keys default to `true`, so deleting a block runs everything. Disabling

--- a/METRICS_ROADMAP.md
+++ b/METRICS_ROADMAP.md
@@ -29,7 +29,7 @@ No significant post-processing required.
 | [#10](https://github.com/corsa-center/metrics/issues/10) | 4.2.3 Active Maintenance | `collectors/sustainability/active_maintenance.py` | ✅ Done |
 | [#16](https://github.com/corsa-center/metrics/issues/16) | 4.2.10 Project Longevity & Community Health | `orchestrator.py` (derived from `active_maintenance.py`) | ✅ Done |
 | [#18](https://github.com/corsa-center/metrics/issues/18) | 4.3.2 Development Practices | `ci_cd.py` + `dev_tooling.py` | ✅ Done (5/5) |
-| [#21](https://github.com/corsa-center/metrics/issues/21) | 4.3.5 Accessibility (portable build systems) | `collectors/quality/accessibility.py` | ✅ Done |
+| [#21](https://github.com/corsa-center/metrics/issues/21) | 4.3.5 Accessibility | `accessibility.py` + `deployment_environments.py` | ✅ Done (partial — 3/5; architecture & platform docs TBD) |
 | — | **OpenSSF Best Practices Badge** (Quality) | `collectors/sustainability/openssf_badge.py` | ✅ Done |
 | — | **OpenSSF Scorecard** (Sustainability) | `collectors/sustainability/openssf_scorecard.py` | ✅ Done |
 | — | **CI / GitHub Actions Status** (Quality) | covered by `ci_cd.py` | ✅ Done |
@@ -75,7 +75,7 @@ static analysis tool runs, or non-trivial content parsing.
 | [#11](https://github.com/corsa-center/metrics/issues/11) | 4.2.4 Engagement | `collectors/sustainability/engagement.py` | ✅ Done |
 | [#12](https://github.com/corsa-center/metrics/issues/12) | 4.2.5 Outreach | `collectors/sustainability/outreach.py` | ✅ Done (partial — 5/8; event & training data not in the repo) |
 | [#17](https://github.com/corsa-center/metrics/issues/17) | 4.3.1 Reliability & Robustness | `collectors/quality/test_coverage.py` | ✅ Done (partial — Test Coverage Excellence via Codecov; static analysis/CERT/trend TBD) |
-| [#19](https://github.com/corsa-center/metrics/issues/19) | 4.3.3 Reproducibility | `collectors/quality/reproducibility.py` | ✅ Done |
+| [#19](https://github.com/corsa-center/metrics/issues/19) | 4.3.3 Reproducibility | `collectors/quality/reproducibility.py` | ✅ Done (5/5) |
 | [#20](https://github.com/corsa-center/metrics/issues/20) | 4.3.4 Usability | — | 🔲 Todo |
 | [#22](https://github.com/corsa-center/metrics/issues/22) | 4.3.6 Maintainability & Understandability | `orchestrator.py` (bus factor from `active_maintenance.py`) | ✅ Done (partial — Knowledge Distribution only; complexity/quality/docs TBD) |
 

--- a/collectors/quality/deployment_environments.py
+++ b/collectors/quality/deployment_environments.py
@@ -120,8 +120,19 @@ class DeploymentEnvironmentCollector(GitHubCollectorBase):
             return None
 
     def _calculate_score(self, detected: Dict[str, List[str]]) -> Dict[str, Any]:
+        """Summarise coverage by OS family.
+
+        Individual runner labels stay in `os_families` for anyone consuming the
+        JSON, but they are not rendered: "ubuntu-24.04, ubuntu-latest,
+        windows-11, windows-2022, windows-latest, macos-15, macos-latest" is a
+        wall of text that says nothing the family list doesn't already say.
+        """
         names = sorted(detected)
         passing = len(names) >= _MIN_OS_FAMILIES
+        if names:
+            value = f"{len(names)} environment{'s' if len(names) != 1 else ''}: " + ", ".join(names)
+        else:
+            value = "No CI runner environments detected"
         return {
             "score": 1 if passing else 0,
             "max_score": 1,
@@ -129,11 +140,8 @@ class DeploymentEnvironmentCollector(GitHubCollectorBase):
             "sub_scores": {
                 "deployment_environment_testing": {
                     "label": "Deployment Environment Testing",
-                    "value": ", ".join(names) if names
-                             else "No CI runner environments detected",
-                    "detail": "; ".join(
-                        f"{f}: {', '.join(labels[:4])}" for f, labels in sorted(detected.items())
-                    ) or None,
+                    "value": value,
+                    "detail": None,
                     "passing": passing,
                 }
             },

--- a/collectors/quality/deployment_environments.py
+++ b/collectors/quality/deployment_environments.py
@@ -1,0 +1,151 @@
+"""
+Deployment Environment Collector (CASS Report Section 4.3.5 — Accessibility)
+
+Fills "Deployment Environment Testing" by reading the CI workflow definitions
+and working out which operating-system families the project actually builds and
+tests on.
+
+Runner labels are matched anywhere in the workflow text rather than only after
+`runs-on:`, because most real workflows write `runs-on: ${{ matrix.os }}` and
+list the concrete runners in the matrix block further down.
+
+Labels are folded to OS *families* — a project testing ubuntu-22.04 and
+ubuntu-24.04 covers one environment, not two.
+"""
+
+import asyncio
+import base64
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+_WORKFLOWS_DIR = ".github/workflows"
+
+# Runner label prefixes that GitHub-hosted and common self-hosted runners use,
+# mapped to the OS family they represent.
+# The version suffix matters: matching any word after the family name sweeps up
+# job names like "macos-clang" and "linux-oneapi", which are toolchain labels
+# rather than runners and make the reported detail wrong.
+_RUNNER_SUFFIX = r"(?:latest|\d+(?:\.\d+)?)"
+_RUNNER_FAMILIES = {
+    "Linux": re.compile(rf"\b(?:ubuntu|debian|fedora|rhel|centos)-{_RUNNER_SUFFIX}\b", re.I),
+    "Windows": re.compile(rf"\bwindows-{_RUNNER_SUFFIX}\b", re.I),
+    "macOS": re.compile(rf"\bmacos-{_RUNNER_SUFFIX}\b", re.I),
+}
+
+# Cap on workflow files read, to bound the request count on repositories that
+# carry dozens of them (HDF5 has ~40).
+_MAX_WORKFLOW_FILES = 25
+
+# Building on more than one OS family is what this sub-metric is asking about.
+_MIN_OS_FAMILIES = 2
+
+
+class DeploymentEnvironmentCollector(GitHubCollectorBase):
+    """Detects the OS families a project's CI exercises (Section 4.3.5)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        owner_repo = self._extract_owner_repo(package.get("repo_url", ""))
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {package.get('repo_url')}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Collecting deployment environment metrics for {repo_name}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            files = await self._list_workflows(client, owner, repo)
+            if not files:
+                return self._empty_result(repo_name, f"{owner}/{repo}")
+
+            contents = await asyncio.gather(
+                *[self._read_workflow(client, f["url"]) for f in files[:_MAX_WORKFLOW_FILES]],
+                return_exceptions=True,
+            )
+
+        families: Dict[str, set] = {name: set() for name in _RUNNER_FAMILIES}
+        for text in contents:
+            if isinstance(text, Exception) or not text:
+                continue
+            for family, pattern in _RUNNER_FAMILIES.items():
+                for label in pattern.findall(text):
+                    families[family].add(label.lower())
+
+        detected = {f: sorted(labels) for f, labels in families.items() if labels}
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "workflow_count": len(files),
+            "workflows_scanned": min(len(files), _MAX_WORKFLOW_FILES),
+            "os_families": detected,
+            "overall_score": self._calculate_score(detected),
+        }
+
+    async def _list_workflows(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> List[Dict[str, str]]:
+        """Workflow definition files in .github/workflows."""
+        url = f"https://api.github.com/repos/{owner}/{repo}/contents/{_WORKFLOWS_DIR}"
+        try:
+            resp = await client.get(url, headers=self.github_headers)
+            if resp.status_code != 200:
+                return []
+            entries = resp.json()
+            if not isinstance(entries, list):
+                return []
+            return [
+                {"name": e["name"], "url": e["download_url"]}
+                for e in entries
+                if e.get("name", "").endswith((".yml", ".yaml")) and e.get("download_url")
+            ]
+        except Exception as e:
+            logger.debug(f"Could not list workflows: {e}")
+            return []
+
+    async def _read_workflow(self, client: httpx.AsyncClient, url: str) -> Optional[str]:
+        """Fetch a workflow file's raw text."""
+        try:
+            resp = await client.get(url)
+            return resp.text if resp.status_code == 200 else None
+        except Exception as e:
+            logger.debug(f"Could not read workflow {url}: {e}")
+            return None
+
+    def _calculate_score(self, detected: Dict[str, List[str]]) -> Dict[str, Any]:
+        names = sorted(detected)
+        passing = len(names) >= _MIN_OS_FAMILIES
+        return {
+            "score": 1 if passing else 0,
+            "max_score": 1,
+            "percentage": 100.0 if passing else 0.0,
+            "sub_scores": {
+                "deployment_environment_testing": {
+                    "label": "Deployment Environment Testing",
+                    "value": ", ".join(names) if names
+                             else "No CI runner environments detected",
+                    "detail": "; ".join(
+                        f"{f}: {', '.join(labels[:4])}" for f, labels in sorted(detected.items())
+                    ) or None,
+                    "passing": passing,
+                }
+            },
+        }
+
+    def _empty_result(self, repo_name: str, repository: str = "unknown") -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": repository,
+            "timestamp": self._get_timestamp(),
+            "workflow_count": 0,
+            "workflows_scanned": 0,
+            "os_families": {},
+            "overall_score": self._calculate_score({}),
+        }

--- a/collectors/quality/reproducibility.py
+++ b/collectors/quality/reproducibility.py
@@ -55,13 +55,34 @@ _FILE_CHECKS: Dict[str, Dict[str, List[str]]] = {
         "codemeta.json": ["codemeta.json"],
         "Zenodo metadata": [".zenodo.json", "zenodo.json"],
     },
+    # Documentation telling someone how to rebuild the software as released.
+    # Reproducibility that isn't written down can't be followed by anyone else.
+    "reproducibility_docs": {
+        "Install / build guide": [
+            "INSTALL.md", "INSTALL", "INSTALL.txt", "BUILD.md", "BUILDING.md",
+            "docs/install.md", "docs/installation.md", "doc/install.md",
+            "docs/INSTALL.md", "release_docs/INSTALL", "release_docs/INSTALL.md",
+        ],
+        "Release / build notes": [
+            "CHANGELOG.md", "CHANGELOG", "NEWS.md", "RELEASE.txt",
+            "release_docs/CHANGELOG.md", "release_docs/RELEASE.txt",
+            "docs/changelog.md", "HISTORY.md",
+        ],
+        # Dockerfile is deliberately absent: the "containers" category already
+        # scores it, and counting it twice would inflate the section.
+        "Environment specification": [
+            "environment.yml", "environment.yaml", "spack.yaml", "spack.lock",
+            ".devcontainer/devcontainer.json", ".devcontainer.json",
+        ],
+    },
 }
 
 # Weights used to compute the overall percentage score.
 _WEIGHTS = {
-    "containers": 0.25,
-    "dependency_pinning": 0.35,
-    "fair4rs_metadata": 0.25,
+    "containers": 0.20,
+    "dependency_pinning": 0.30,
+    "fair4rs_metadata": 0.20,
+    "reproducibility_docs": 0.15,
     "semantic_versioning": 0.15,
 }
 
@@ -97,6 +118,7 @@ class ReproducibilityCollector(GitHubCollectorBase):
             "has_container": bool(categories["containers"]["found"]),
             "has_dependency_pinning": bool(categories["dependency_pinning"]["found"]),
             "has_fair4rs_metadata": bool(categories["fair4rs_metadata"]["found"]),
+            "has_reproducibility_docs": bool(categories["reproducibility_docs"]["found"]),
             "uses_semantic_versioning": semver["uses_semver"],
             "categories": categories,
             "overall_score": overall,
@@ -220,10 +242,13 @@ class ReproducibilityCollector(GitHubCollectorBase):
     def _compute_overall(self, categories: Dict[str, Any]) -> Dict[str, Any]:
         weighted = 0.0
         for cat, weight in _WEIGHTS.items():
+            # A category can be absent if its scan failed; treat that as zero
+            # rather than letting a KeyError take down the whole dimension.
+            data = categories.get(cat, {})
             if cat == "semantic_versioning":
-                pct = 100.0 if categories[cat].get("uses_semver") else 0.0
+                pct = 100.0 if data.get("uses_semver") else 0.0
             else:
-                pct = categories[cat].get("percentage", 0.0)
+                pct = data.get("percentage", 0.0)
             weighted += pct * weight
 
         return {
@@ -240,6 +265,7 @@ class ReproducibilityCollector(GitHubCollectorBase):
             "has_container": False,
             "has_dependency_pinning": False,
             "has_fair4rs_metadata": False,
+            "has_reproducibility_docs": False,
             "uses_semantic_versioning": False,
             "categories": {},
             "overall_score": {"score": 0.0, "max_score": 100.0, "percentage": 0.0},

--- a/collectors/sustainability/welcomeness.py
+++ b/collectors/sustainability/welcomeness.py
@@ -1,0 +1,167 @@
+"""
+Welcomeness Collector (CASS Report Section 4.2.6)
+
+Covers the one sub-metric of the seven that repository data can answer:
+Decision-Making Visibility — whether the project conducts and records its
+decisions somewhere the community can see.
+
+The other six (CHAOSS community experience, response tone, sentiment,
+contributor journey mapping, language review, leadership representation) all
+need natural-language analysis of community conversations or demographic data
+about maintainers, and stay uncollected.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import httpx
+
+from collectors.sustainability.base import GitHubCollectorBase
+
+logger = logging.getLogger(__name__)
+
+# Places a project can conduct decision-making in the open. Grouped so any
+# variant counts once.
+_DECISION_PATHS = {
+    "Roadmap": [
+        "ROADMAP.md", "ROADMAP", "docs/roadmap.md", "doc/roadmap.md",
+        ".github/ROADMAP.md",
+    ],
+    "Meeting notes": [
+        "meetings", "docs/meetings", "MEETINGS.md", "doc/meetings",
+        "docs/meeting-notes", "notes/meetings",
+    ],
+    "Decision records": [
+        "docs/adr", "adr", "docs/decisions", "doc/adr", "DECISIONS.md",
+        "docs/architecture-decisions",
+    ],
+    "Governance document": [
+        "GOVERNANCE.md", "docs/GOVERNANCE.md", ".github/GOVERNANCE.md",
+    ],
+}
+
+# Repository features that expose discussion and documentation publicly.
+_PUBLIC_CHANNELS = {
+    "has_discussions": "GitHub Discussions",
+    "has_wiki": "Wiki",
+    "has_pages": "GitHub Pages",
+}
+
+# Two independent signals of open decision-making is a meaningful bar: one
+# alone (a wiki nobody writes in, say) says very little.
+_MIN_VISIBILITY_SIGNALS = 2
+
+
+class WelcomenessCollector(GitHubCollectorBase):
+    """Collects decision-making visibility signals (Section 4.2.6)."""
+
+    async def collect(self, package: Dict[str, Any]) -> Dict[str, Any]:
+        repo_name = package.get("name", "Unknown")
+        owner_repo = self._extract_owner_repo(package.get("repo_url", ""))
+        if not owner_repo:
+            logger.error(f"Could not extract owner/repo from {package.get('repo_url')}")
+            return self._empty_result(repo_name)
+
+        owner, repo = owner_repo
+        logger.info(f"Collecting welcomeness metrics for {repo_name}")
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            channels, documents = await asyncio.gather(
+                self._get_public_channels(client, owner, repo),
+                self._find_decision_documents(client, owner, repo),
+                return_exceptions=True,
+            )
+
+        if isinstance(channels, Exception):
+            logger.warning(f"Channel lookup failed: {channels}")
+            channels = []
+        if isinstance(documents, Exception):
+            logger.warning(f"Decision document scan failed: {documents}")
+            documents = {"found": [], "details": {}}
+
+        return {
+            "package_name": repo_name,
+            "repository": f"{owner}/{repo}",
+            "timestamp": self._get_timestamp(),
+            "public_channels": channels,
+            "decision_documents": documents,
+            "overall_score": self._calculate_score(channels, documents),
+        }
+
+    async def _get_public_channels(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> List[str]:
+        """Discussions / wiki / pages flags, straight off the repository object."""
+        resp = await client.get(
+            f"https://api.github.com/repos/{owner}/{repo}", headers=self.github_headers
+        )
+        if resp.status_code != 200:
+            return []
+        data = resp.json()
+        return [label for flag, label in _PUBLIC_CHANNELS.items() if data.get(flag)]
+
+    async def _find_decision_documents(
+        self, client: httpx.AsyncClient, owner: str, repo: str
+    ) -> Dict[str, Any]:
+        """Roadmaps, meeting notes, decision records and governance docs."""
+
+        async def check(label: str, paths: List[str]) -> Tuple[str, Optional[str]]:
+            for path in paths:
+                url = await self._check_file_exists(client, owner, repo, path)
+                if url:
+                    return label, url
+            return label, None
+
+        results = await asyncio.gather(
+            *[check(label, paths) for label, paths in _DECISION_PATHS.items()]
+        )
+        found, details = [], {}
+        for label, url in results:
+            if url:
+                found.append(label)
+                details[label] = {"exists": True, "url": url}
+            else:
+                details[label] = {"exists": False}
+        return {"found": found, "details": details}
+
+    def _calculate_score(self, channels: List[str], documents: Dict) -> Dict[str, Any]:
+        signals = list(channels) + list(documents.get("found", []))
+        passing = len(signals) >= _MIN_VISIBILITY_SIGNALS
+
+        sub: Dict[str, Dict[str, Any]] = {
+            "decision_making_visibility": {
+                "label": "Decision-Making Visibility",
+                "value": f"{len(signals)} public channel(s)" if signals
+                         else "No public decision-making channels found",
+                "detail": ", ".join(signals) if signals else None,
+                "passing": passing,
+            }
+        }
+        for key, label in [
+            ("chaoss_community_experience", "CHAOSS Community Experience Metrics"),
+            ("response_quality_tone", "Response Quality and Tone Analysis"),
+            ("communication_sentiment", "Communication Sentiment Analysis"),
+            ("contributor_journey", "Contributor Journey Mapping"),
+            ("language_communication", "Language and Communication Review"),
+            ("leadership_representation", "Leadership Role Representation"),
+        ]:
+            sub[key] = {"label": label, "value": None, "passing": False, "not_collected": True}
+
+        score = sum(1 for s in sub.values() if s.get("passing"))
+        return {
+            "score": score,
+            "max_score": len(sub),
+            "percentage": round(score / len(sub) * 100, 2),
+            "sub_scores": sub,
+        }
+
+    def _empty_result(self, repo_name: str) -> Dict[str, Any]:
+        return {
+            "package_name": repo_name,
+            "repository": "unknown",
+            "timestamp": self._get_timestamp(),
+            "public_channels": [],
+            "decision_documents": {"found": [], "details": {}},
+            "overall_score": self._calculate_score([], {"found": []}),
+        }

--- a/config/orchestrator.yaml
+++ b/config/orchestrator.yaml
@@ -28,6 +28,7 @@ sustainability_collectors:
   active_maintenance: true  # 4.2.3 Active Maintenance, and 4.2.10 + 4.3.6 are derived from it
   engagement: true          # 4.2.4 Engagement
   outreach: true            # 4.2.5 Outreach
+  welcomeness: true         # 4.2.6 Decision-making visibility
   funding: true             # 4.2.8 Financial + 4.2.9 Institutional Support
 
 quality_collectors:
@@ -37,6 +38,7 @@ quality_collectors:
   dev_tooling: true         # 4.3.2 testing, code review, tool integration
   reproducibility: true     # 4.3.3 Reproducibility
   accessibility: true       # 4.3.5 Accessibility
+  deployment_environments: true  # 4.3.5 CI runner OS families
 
 # API credentials
 api_credentials:

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -359,6 +359,15 @@ class MetricsOrchestrator:
             except Exception as e:
                 logger.warning(f"Outreach collection failed for {package['name']}: {e}")
 
+        # 4.2.6 Welcomeness — decision-making visibility
+        if self._sub_enabled("sustainability", "welcomeness"):
+            try:
+                from collectors.sustainability.welcomeness import WelcomenessCollector
+                collector = WelcomenessCollector(github_token=github_token)
+                sub_results["welcomeness"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Welcomeness collection failed for {package['name']}: {e}")
+
         # 4.2.8 + 4.2.9 Funding and institutional affiliation
         if self._sub_enabled("sustainability", "funding"):
             try:
@@ -401,6 +410,8 @@ class MetricsOrchestrator:
             scores.append(sub_results["outreach"].get("overall_score", {}).get("percentage", 0))
         if "funding" in sub_results:
             scores.append(sub_results["funding"].get("overall_score", {}).get("percentage", 0))
+        if "welcomeness" in sub_results:
+            scores.append(sub_results["welcomeness"].get("overall_score", {}).get("percentage", 0))
 
         avg_score = sum(scores) / len(scores) if scores else 0.0
 
@@ -461,6 +472,15 @@ class MetricsOrchestrator:
             except Exception as e:
                 logger.warning(f"Test coverage collection failed for {package['name']}: {e}")
 
+        # 4.3.5 Deployment Environment Testing — CI runner OS families
+        if self._sub_enabled("quality", "deployment_environments"):
+            try:
+                from collectors.quality.deployment_environments import DeploymentEnvironmentCollector
+                collector = DeploymentEnvironmentCollector(github_token=github_token)
+                sub_results["deployment_environments"] = await collector.collect(package)
+            except Exception as e:
+                logger.warning(f"Deployment environment collection failed for {package['name']}: {e}")
+
         # 4.3.2 Testing frameworks, code review coverage, tooling integration
         if self._sub_enabled("quality", "dev_tooling"):
             try:
@@ -492,6 +512,10 @@ class MetricsOrchestrator:
             scores.append(100 if sub_results["static_analysis"].get("has_codeql") else 0)
         if "dev_tooling" in sub_results:
             scores.append(sub_results["dev_tooling"].get("overall_score", {}).get("percentage", 0))
+        if "deployment_environments" in sub_results:
+            scores.append(
+                sub_results["deployment_environments"].get("overall_score", {}).get("percentage", 0)
+            )
 
         avg_score = sum(scores) / len(scores) if scores else 0.0
 
@@ -1140,6 +1164,30 @@ class MetricsOrchestrator:
         else:
             section_425_data = None
 
+        # --- 4.2.6 Welcomeness (PDF §4.2.6 — 7 sub-metrics) ---
+        # Only Decision-Making Visibility is answerable from repository data;
+        # the other six need sentiment/tone analysis or maintainer demographics.
+        welcomeness = sust.get("welcomeness", {})
+        if welcomeness:
+            wsub = welcomeness.get("overall_score", {}).get("sub_scores", {})
+            wel_lines = [
+                _sub_row(wsub, key) for key in [
+                    "chaoss_community_experience",
+                    "response_quality_tone",
+                    "communication_sentiment",
+                    "contributor_journey",
+                    "language_communication",
+                    "leadership_representation",
+                    "decision_making_visibility",
+                ]
+            ]
+            wel_lines.append(
+                f'<p><strong>Score:</strong> {welcomeness.get("overall_score", {}).get("score", 0)}/7</p>'
+            )
+            section_426_data = "\n".join(wel_lines)
+        else:
+            section_426_data = None
+
         # --- 4.2.8 Financial Sustainability / 4.2.9 Institutional Support ---
         # One collector serves both: they rest on the same funding documentation
         # and contributor-affiliation pass.
@@ -1269,7 +1317,10 @@ class MetricsOrchestrator:
                 _repr_row("Environment Management",
                           reproducibility.get("has_dependency_pinning"),
                           ", ".join(dep_found) if dep_found else None),
-                "<p><strong>Reproducibility Documentation:</strong> Not yet collected</p>",
+                _repr_row("Reproducibility Documentation",
+                          reproducibility.get("has_reproducibility_docs"),
+                          ", ".join(cats.get("reproducibility_docs", {}).get("found", []))
+                          or None),
                 f'<p><strong>Score:</strong> {repr_pts}/5</p>',
             ]
             section_433_data = "\n".join(repr_lines)
@@ -1353,6 +1404,7 @@ class MetricsOrchestrator:
         # 1. Portable Build System   2. Container Availability   3. Architecture Compatibility
         # 4. Platform Documentation  5. Deployment Environment Testing
         accessibility = qual.get("accessibility", {})
+        deployment_envs = qual.get("deployment_environments", {})
         if accessibility:
             cats = accessibility.get("categories", {})
             acc_pts = 0
@@ -1369,6 +1421,12 @@ class MetricsOrchestrator:
             build_found = cats.get("build_systems", {}).get("found", [])
             container_found = cats.get("containers", {}).get("found", [])
 
+            # 5. Deployment Environment Testing comes from its own collector, so
+            #    it is rendered with _sub_row and scored alongside the _acc_row
+            #    rows before the Score line is appended.
+            dep_sub = deployment_envs.get("overall_score", {}).get("sub_scores", {})
+            dep_info = dep_sub.get("deployment_environment_testing", {})
+
             acc_lines = [
                 _acc_row("Portable Build System Detection",
                          accessibility.get("has_portable_build_system"),
@@ -1378,9 +1436,12 @@ class MetricsOrchestrator:
                          ", ".join(container_found) if container_found else None),
                 "<p><strong>Architecture Compatibility Analysis:</strong> Not yet collected</p>",
                 "<p><strong>Platform Documentation Evaluation:</strong> Not yet collected</p>",
-                "<p><strong>Deployment Environment Testing:</strong> Not yet collected</p>",
-                f'<p><strong>Score:</strong> {acc_pts}/5</p>',
+                (_sub_row(dep_sub, "deployment_environment_testing") if deployment_envs
+                 else "<p><strong>Deployment Environment Testing:</strong> Not yet collected</p>"),
             ]
+            if dep_info.get("passing"):
+                acc_pts += 1
+            acc_lines.append(f'<p><strong>Score:</strong> {acc_pts}/5</p>')
             section_435_data = "\n".join(acc_lines)
         else:
             section_435_data = None
@@ -1429,6 +1490,7 @@ class MetricsOrchestrator:
         section_423_data = self._apply_section_overrides(section_423_data, ov.get("4.2.3", {}))
         section_424_data = self._apply_section_overrides(section_424_data, ov.get("4.2.4", {}))
         section_425_data = self._apply_section_overrides(section_425_data, ov.get("4.2.5", {}))
+        section_426_data = self._apply_section_overrides(section_426_data, ov.get("4.2.6", {}))
         section_428_data = self._apply_section_overrides(section_428_data, ov.get("4.2.8", {}))
         section_429_data = self._apply_section_overrides(section_429_data, ov.get("4.2.9", {}))
         section_4210_data = self._apply_section_overrides(section_4210_data, ov.get("4.2.10", {}))
@@ -1456,7 +1518,7 @@ class MetricsOrchestrator:
                 "4.2.3": {"title": "Active Maintenance", "data": section_423_data},
                 "4.2.4": {"title": "Engagement", "data": section_424_data},
                 "4.2.5": {"title": "Outreach",              "data": section_425_data or _stub("4.2.5")},
-                "4.2.6": {"title": "Welcomeness",            "data": _stub("4.2.6")},
+                "4.2.6": {"title": "Welcomeness",            "data": section_426_data or _stub("4.2.6")},
                 "4.2.7": {"title": "Collaboration",          "data": _stub("4.2.7")},
                 "4.2.8": {"title": "Financial Sustainability","data": section_428_data or _stub("4.2.8")},
                 "4.2.9": {"title": "Institutional & Organizational Support", "data": section_429_data or _stub("4.2.9")},

--- a/tests/test_deployment_environments.py
+++ b/tests/test_deployment_environments.py
@@ -69,11 +69,22 @@ class TestScoring:
         assert "No CI runner" in info["value"]
         assert info["detail"] is None
 
-    def test_value_lists_families_alphabetically(self, collector):
-        s = collector._calculate_score(
-            {"Windows": ["windows-latest"], "Linux": ["ubuntu-latest"]}
+    def test_value_is_a_summary_not_a_label_dump(self, collector):
+        s = collector._calculate_score({
+            "Windows": ["windows-11", "windows-2022", "windows-latest"],
+            "Linux": ["ubuntu-24.04", "ubuntu-latest"],
+        })
+        info = s["sub_scores"]["deployment_environment_testing"]
+        assert info["value"] == "2 environments: Linux, Windows"
+        # Individual runner labels are kept in os_families, not rendered.
+        assert info["detail"] is None
+        assert "ubuntu-24.04" not in info["value"]
+
+    def test_single_environment_is_singular(self, collector):
+        s = collector._calculate_score({"Linux": ["ubuntu-latest"]})
+        assert s["sub_scores"]["deployment_environment_testing"]["value"] == (
+            "1 environment: Linux"
         )
-        assert s["sub_scores"]["deployment_environment_testing"]["value"] == "Linux, Windows"
 
 
 class TestEmptyResult:

--- a/tests/test_deployment_environments.py
+++ b/tests/test_deployment_environments.py
@@ -1,0 +1,84 @@
+"""Unit tests for DeploymentEnvironmentCollector (CASS Section 4.3.5)."""
+
+import pytest
+
+from collectors.quality.deployment_environments import (
+    DeploymentEnvironmentCollector, _RUNNER_FAMILIES,
+)
+
+
+@pytest.fixture
+def collector():
+    return DeploymentEnvironmentCollector()
+
+
+def _families(text):
+    out = {}
+    for family, pattern in _RUNNER_FAMILIES.items():
+        hits = sorted({m.lower() for m in pattern.findall(text)})
+        if hits:
+            out[family] = hits
+    return out
+
+
+class TestRunnerDetection:
+    def test_matches_literal_runs_on(self):
+        assert _families("runs-on: ubuntu-latest") == {"Linux": ["ubuntu-latest"]}
+
+    def test_matches_runners_declared_in_a_matrix(self):
+        # The common real-world shape: runs-on indirects through the matrix.
+        text = """
+        runs-on: ${{ matrix.os }}
+        strategy:
+          matrix:
+            os: [ubuntu-24.04, windows-2022, macos-15]
+        """
+        assert set(_families(text)) == {"Linux", "Windows", "macOS"}
+
+    @pytest.mark.parametrize("label", ["macos-clang", "linux-oneapi", "ubuntu-gcc", "windows-msvc"])
+    def test_toolchain_job_names_are_not_runners(self, label):
+        # These appear in job names; treating them as runners made the reported
+        # environment list wrong.
+        assert _families(f"name: {label}") == {}
+
+    def test_versioned_and_latest_both_count(self):
+        assert _families("windows-11 windows-latest")["Windows"] == [
+            "windows-11", "windows-latest"
+        ]
+
+    def test_point_versions(self):
+        assert _families("ubuntu-22.04")["Linux"] == ["ubuntu-22.04"]
+
+
+class TestScoring:
+    def test_single_family_fails(self, collector):
+        s = collector._calculate_score({"Linux": ["ubuntu-latest"]})
+        assert not s["sub_scores"]["deployment_environment_testing"]["passing"]
+
+    def test_two_families_pass(self, collector):
+        s = collector._calculate_score(
+            {"Linux": ["ubuntu-latest"], "Windows": ["windows-latest"]}
+        )
+        assert s["sub_scores"]["deployment_environment_testing"]["passing"]
+        assert s["score"] == 1
+
+    def test_no_families(self, collector):
+        s = collector._calculate_score({})
+        info = s["sub_scores"]["deployment_environment_testing"]
+        assert not info["passing"]
+        assert "No CI runner" in info["value"]
+        assert info["detail"] is None
+
+    def test_value_lists_families_alphabetically(self, collector):
+        s = collector._calculate_score(
+            {"Windows": ["windows-latest"], "Linux": ["ubuntu-latest"]}
+        )
+        assert s["sub_scores"]["deployment_environment_testing"]["value"] == "Linux, Windows"
+
+
+class TestEmptyResult:
+    def test_invalid_url(self, collector):
+        import asyncio
+        r = asyncio.run(collector.collect({"name": "x", "repo_url": "nope"}))
+        assert r["os_families"] == {}
+        assert r["overall_score"]["score"] == 0

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -91,6 +91,7 @@ class TestComputeOverall:
             "containers":          {"found": ["Docker"], "percentage": 100.0},
             "dependency_pinning":  {"found": ["poetry.lock"], "percentage": 100.0},
             "fair4rs_metadata":    {"found": ["CITATION.cff"], "percentage": 100.0},
+            "reproducibility_docs": {"found": ["INSTALL.md"], "percentage": 100.0},
             "semantic_versioning": {"uses_semver": True},
         }
         result = collector._compute_overall(categories)
@@ -101,6 +102,7 @@ class TestComputeOverall:
             "containers":          {"found": [], "percentage": 0.0},
             "dependency_pinning":  {"found": [], "percentage": 0.0},
             "fair4rs_metadata":    {"found": [], "percentage": 0.0},
+            "reproducibility_docs": {"found": [], "percentage": 0.0},
             "semantic_versioning": {"uses_semver": False},
         }
         result = collector._compute_overall(categories)
@@ -111,11 +113,17 @@ class TestComputeOverall:
             "containers":          {"found": [], "percentage": 0.0},
             "dependency_pinning":  {"found": [], "percentage": 0.0},
             "fair4rs_metadata":    {"found": ["CITATION.cff"], "percentage": 100.0},
+            "reproducibility_docs": {"found": [], "percentage": 0.0},
             "semantic_versioning": {"uses_semver": True},
         }
         result = collector._compute_overall(categories)
-        # fair4rs 0.25 * 100 + semver 0.15 * 100 = 40.0
-        assert result["percentage"] == 40.0
+        # fair4rs 0.20 * 100 + semver 0.15 * 100 = 35.0
+        assert result["percentage"] == 35.0
+
+    def test_missing_category_scores_zero_instead_of_raising(self, collector):
+        # A failed sub-scan must not take down the whole dimension.
+        result = collector._compute_overall({"semantic_versioning": {"uses_semver": True}})
+        assert result["percentage"] == 15.0
 
 
 class TestScanFiles:

--- a/tests/test_welcomeness.py
+++ b/tests/test_welcomeness.py
@@ -1,0 +1,49 @@
+"""Unit tests for WelcomenessCollector (CASS Section 4.2.6)."""
+
+import pytest
+
+from collectors.sustainability.welcomeness import WelcomenessCollector
+
+
+@pytest.fixture
+def collector():
+    return WelcomenessCollector()
+
+
+class TestScoring:
+    def _score(self, collector, channels=(), docs=()):
+        return collector._calculate_score(list(channels), {"found": list(docs)})
+
+    def test_six_submetrics_stay_uncollected(self, collector):
+        sub = self._score(collector)["sub_scores"]
+        assert sum(1 for v in sub.values() if v.get("not_collected")) == 6
+        assert self._score(collector)["max_score"] == 7
+
+    def test_one_signal_is_not_enough(self, collector):
+        s = self._score(collector, channels=["Wiki"])
+        assert not s["sub_scores"]["decision_making_visibility"]["passing"]
+
+    def test_two_signals_pass(self, collector):
+        s = self._score(collector, channels=["Wiki", "GitHub Discussions"])
+        assert s["sub_scores"]["decision_making_visibility"]["passing"]
+        assert s["score"] == 1
+
+    def test_channels_and_documents_both_count(self, collector):
+        s = self._score(collector, channels=["Wiki"], docs=["Roadmap"])
+        info = s["sub_scores"]["decision_making_visibility"]
+        assert info["passing"]
+        assert info["detail"] == "Wiki, Roadmap"
+
+    def test_no_signals(self, collector):
+        info = self._score(collector)["sub_scores"]["decision_making_visibility"]
+        assert not info["passing"]
+        assert "No public decision-making channels" in info["value"]
+        assert info["detail"] is None
+
+
+class TestEmptyResult:
+    def test_invalid_url(self, collector):
+        import asyncio
+        r = asyncio.run(collector.collect({"name": "x", "repo_url": "nope"}))
+        assert r["public_channels"] == []
+        assert r["overall_score"]["max_score"] == 7


### PR DESCRIPTION
The three cheapest remaining gaps — each reads data the framework was already in a position to get.

| Section | Before | After |
|---|---|---|
| 4.2.6 Welcomeness | ⬜ stub | 1/7 |
| 4.3.3 Reproducibility | 4/5 | **5/5** |
| 4.3.5 Accessibility | 2/5 | 3/5 |

## 4.2.6 Decision-Making Visibility

`has_discussions` / `has_wiki` / `has_pages` come straight off the repository object, plus a scan for a roadmap, meeting notes, decision records or governance document. Passes at two independent signals — one alone (a wiki nobody writes in) says very little. The other six sub-metrics need sentiment analysis or maintainer demographics and stay uncollected.

## 4.3.5 Deployment Environment Testing

Reads the CI workflow definitions and folds runner labels into OS families.

Two things worth flagging:

- Labels are matched **anywhere in the file**, not just after `runs-on:`. Most real workflows write `runs-on: ${{ matrix.os }}` and list the concrete runners in the matrix block further down — matching only `runs-on:` finds nothing on HDF5.
- The label pattern **requires a version suffix** (`latest`, or digits). My first pass matched any word after the family name and swept up `macos-clang`, `linux-oneapi` and `ubuntu-gcc` — those are toolchain job names, not runners, and they made the reported environment list wrong. HDF5 now reports Linux/Windows/macOS from genuine labels only.

## 4.3.3 Reproducibility Documentation

New file category: install/build guide, release notes, environment specification.

`Dockerfile` is deliberately **excluded** from the environment list — the existing `containers` category already scores it, and counting it in both would inflate the section. Weights rebalanced to keep the sum at 1.0.

Also: `_compute_overall` now tolerates a missing category instead of raising `KeyError`, so a failed sub-scan can't take down the whole dimension. Covered by a test.

## Verification

19 new tests, **207 pass**. Live-run against HDFGroup/hdf5, and the rendered HTML re-checked through the dashboard's own `parseScore()` — every section's parsed total still matches its hardcoded blade count.

Advances #19 and #21.